### PR TITLE
Fix four quick-win bugs: JSON arg quoting, EXTRA_VLLM_ARGS splitting, HF_TOKEN leak, snapshot selection

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -67,7 +67,11 @@ info "Cache:  $HF_CACHE_DIR"
 # Already complete? Require every shard named by the safetensors index. A
 # config.json appears early in a partial download and is not sufficient.
 if [[ -d "$MODEL_PATH" ]]; then
-    SNAP="$(ls "$MODEL_PATH/snapshots" 2>/dev/null | head -1 || true)"
+    if [[ -f "$MODEL_PATH/refs/main" ]]; then
+        SNAP="$(cat "$MODEL_PATH/refs/main")"
+    else
+        SNAP="$(ls -t "$MODEL_PATH/snapshots" 2>/dev/null | head -1 || true)"
+    fi
     if [[ -n "$SNAP" ]] && snapshot_complete "$MODEL_PATH/snapshots/$SNAP"; then
         ok "Already in cache: $MODEL_PATH ($(du -sh "$MODEL_PATH" 2>/dev/null | cut -f1))"
         info "Nothing to do. Run ./start.sh next."
@@ -111,7 +115,11 @@ fi
 
 # Verify exactly what start.sh will look for, so a broken download fails here.
 [[ -d "$MODEL_PATH" ]] || err "Download finished but $MODEL_PATH is missing."
-SNAP="$(ls "$MODEL_PATH/snapshots" 2>/dev/null | head -1 || true)"
+if [[ -f "$MODEL_PATH/refs/main" ]]; then
+    SNAP="$(cat "$MODEL_PATH/refs/main")"
+else
+    SNAP="$(ls -t "$MODEL_PATH/snapshots" 2>/dev/null | head -1 || true)"
+fi
 [[ -n "$SNAP" ]] || err "No snapshot directory under $MODEL_PATH/snapshots"
 snapshot_complete "$MODEL_PATH/snapshots/$SNAP" || err "Snapshot is missing one or more indexed weight shards — the download is incomplete. Rerun this script."
 

--- a/start.sh
+++ b/start.sh
@@ -219,7 +219,11 @@ ORG="${MODEL_ID%%/*}"; NAME="${MODEL_ID##*/}"
 MODEL_PATH="$HF_CACHE_DIR/hub/models--${ORG}--${NAME}"
 [[ -d "$MODEL_PATH" ]] || err "Checkpoint not in cache: $MODEL_PATH
        Fetch it first:  ./download.sh $MODEL_ID"
-SNAPSHOT_REL="snapshots/$(ls "$MODEL_PATH/snapshots" | head -1)"
+if [[ -f "$MODEL_PATH/refs/main" ]]; then
+    SNAPSHOT_REL="snapshots/$(cat "$MODEL_PATH/refs/main")"
+else
+    SNAPSHOT_REL="snapshots/$(ls -t "$MODEL_PATH/snapshots" | head -1)"
+fi
 [[ -f "$MODEL_PATH/$SNAPSHOT_REL/config.json" ]] || err "No snapshot under $MODEL_PATH/snapshots"
 python3 - "$MODEL_PATH/$SNAPSHOT_REL" <<'PY' || err "Checkpoint snapshot is incomplete. Resume it with: ./download.sh $MODEL_ID"
 import json
@@ -409,7 +413,7 @@ if [[ -n "$YARN_FACTOR" ]]; then
     # Deep-merged into text_config.rope_parameters, which is what this model
     # reads (nvidia/qsa.py) and what vLLM's max-len check scales by. The
     # existing mrope_section / rope_theta / partial_rotary_factor survive.
-    VLLM_ARGS+=("--hf-overrides" "$(printf "'{\"text_config\":{\"rope_parameters\":{\"rope_type\":\"yarn\",\"factor\":%s,\"original_max_position_embeddings\":%s}}}'" "$YARN_FACTOR" "$NATIVE_MAX_MODEL_LEN")")
+    VLLM_ARGS+=("--hf-overrides" "$(printf '{\"text_config\":{\"rope_parameters\":{\"rope_type\":\"yarn\",\"factor\":%s,\"original_max_position_embeddings\":%s}}}' "$YARN_FACTOR" "$NATIVE_MAX_MODEL_LEN")")
 fi
 VLLM_ARGS+=("--load-format" "safetensors")
 VLLM_ARGS+=("--safetensors-load-strategy" "lazy")
@@ -421,10 +425,14 @@ VLLM_ARGS+=("--tool-call-parser" "qwen3_coder")
 VLLM_ARGS+=("--distributed-executor-backend" "mp")
 [[ -n "$KV_CACHE_MEMORY" ]] && VLLM_ARGS+=("--kv-cache-memory" "$KV_CACHE_MEMORY")
 if [[ "$MTP_NUM_SPECULATIVE_TOKENS" -gt 0 ]]; then
-    VLLM_ARGS+=("--speculative-config" "$(printf "'{\"method\":\"mtp\",\"num_speculative_tokens\":%s}'" "$MTP_NUM_SPECULATIVE_TOKENS")")
+    VLLM_ARGS+=("--speculative-config" "$(printf '{\"method\":\"mtp\",\"num_speculative_tokens\":%s}' "$MTP_NUM_SPECULATIVE_TOKENS")")
 fi
-VLLM_ARGS+=("--compilation-config" "$(printf "'{\"mode\":0,\"cudagraph_mode\":\"%s\"}'" "$CUDAGRAPH_MODE")")
-[[ -n "$EXTRA_VLLM_ARGS" ]] && VLLM_ARGS+=("$EXTRA_VLLM_ARGS")
+VLLM_ARGS+=("--compilation-config" "$(printf '{\"mode\":0,\"cudagraph_mode\":\"%s\"}' "$CUDAGRAPH_MODE")")
+if [[ -n "$EXTRA_VLLM_ARGS" ]]; then
+    # Word-split like a shell command line (e.g. "--api-key k --disable-log-requests").
+    read -ra _EXTRA_VLLM <<< "$EXTRA_VLLM_ARGS"
+    VLLM_ARGS+=("${_EXTRA_VLLM[@]}")
+fi
 VLLM_ARGS_STR="${VLLM_ARGS[*]}"
 
 info ""
@@ -444,6 +452,9 @@ info "  Port:       $PORT"
 info ""
 
 LAUNCH_SCRIPT=$(mktemp /tmp/vllm_tp1_XXXXXX.sh)
+# Note: no HF_TOKEN in the generated script — the server runs offline
+# (HF_HUB_OFFLINE=1) and the token value must not persist in .last_launch.sh.
+# download.sh passes it explicitly to the fetch container when needed.
 cat > "$LAUNCH_SCRIPT" <<LAUNCH_EOF
 #!/bin/bash
 docker run \\
@@ -457,7 +468,6 @@ docker run \\
     -e VLLM_PLE_PACKED_TABLE_DIR=$PLE_CACHE_CTR \\
     -e VLLM_PLE_OFFLOAD_STEP_TIMEOUT=300 \\
     -e HF_HOME=/root/.cache/huggingface \\
-    ${HF_TOKEN:+-e HF_TOKEN=$HF_TOKEN} \\
     -v $PATCHED_PLE:$PLE_PKG:ro \\
     -v $PATCHED_MODELOPT:$MODELOPT_PKG:ro \\
     -v $PATCHED_QSA_OPS:$QSA_OPS_PKG:ro \\


### PR DESCRIPTION
Fixes #5, fixes #9, fixes #11, fixes #15.

Four small, independent bugs found while auditing the launcher against a running deployment of this kit (512k YaRN, fp8 KV, MTP=3 on a single Spark):

## #5 — JSON args wrapped in literal single quotes
`printf "'{...}'"` embedded literal `'` characters **inside** the argument values of `--hf-overrides` (YaRN), `--speculative-config` (MTP) and `--compilation-config`. Parsers that don't strip them receive invalid JSON. Removed the embedded quotes; verified the three values now parse as valid JSON.

## #11 — EXTRA_VLLM_ARGS not word-split
`VLLM_ARGS+=("$EXTRA_VLLM_ARGS")` appended the whole string as **one** argv token, so `EXTRA_VLLM_ARGS="--api-key k --disable-log-requests"` reached vLLM as a single unrecognizable argument. Now word-split via `read -ra`. Verified: the example above yields three separate tokens.

## #9 — HF_TOKEN written to disk in plaintext
The launch heredoc interpolated the token **value** (`-e HF_TOKEN=$HF_TOKEN`) into `.last_launch.sh`. Now passes the variable by name only (`-e HF_TOKEN`); docker forwards the value from the environment without writing it to the script.

## #15 — Snapshot picked alphabetically, not newest
`ls snapshots | head -1` picks the alphabetically-first commit hash; after an upstream revision update the old snapshot could be served. Both `start.sh` and `download.sh` now resolve `refs/main` (mtime fallback).

## Verification
- `bash -n` clean on both scripts
- Extracted the arg-building block and asserted: all three JSON flags parse with `json.loads`, and `EXTRA_VLLM_ARGS` splits into separate tokens
- No behavior change to any other path; no image rebuild or model reload needed