### PR TITLE
Ops batch: memwatch cgroup fallback, smoke test, systemd unit, monitoring docs

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -16,7 +16,15 @@ KV_CACHE_DTYPE=fp8                  # fp8 = ~1.85x KV pool, enables a 1M context
                                     # Set to auto/bfloat16 for BF16 KV. Measured here:
                                     # Measured: -2.7% prefill @400k, -6.1% @32k, -4%
                                     # decode, 11/11 on the reasoning suite (same as BF16).
-MAX_NUM_SEQS=4                      # concurrent sequences (see README for KV headroom)
+MAX_NUM_SEQS=4                      # concurrent sequences. NOTE: low values flatline aggregate
+                                    # throughput in benchmarks (queued requests look like GPU
+                                    # saturation): at 4 seqs ~86 tok/s aggregate, while the same
+                                    # box scales past 260 tok/s at 48 streams (short prompts).
+                                    # The KV pool bounds concurrency: fp8/KV_TARGET_GIB=20 holds
+                                    # ~1.4M tokens, i.e. ~44 concurrent 32k requests or ~2.7 full
+                                    # 512k ones. 8-16 is safe for typical <=32k workloads; keep 4
+                                    # only if you routinely serve near-full-context requests.
+                                    # Watch vllm:num_requests_waiting on /metrics to see queueing.
 MAX_NUM_BATCHED_TOKENS=2048         # prefill chunk width. Raising this to 8192 buys ~11% prefill
                                     # and ~10% off TTFT, paid for out of the KV pool (~3%).
                                     # See the README prefill table before changing it.

--- a/.env.sample
+++ b/.env.sample
@@ -20,9 +20,10 @@ MAX_NUM_SEQS=4                      # concurrent sequences. NOTE: low values fla
                                     # throughput in benchmarks (queued requests look like GPU
                                     # saturation): at 4 seqs ~86 tok/s aggregate, while the same
                                     # box scales past 260 tok/s at 48 streams (short prompts).
-                                    # The KV pool bounds concurrency: fp8/KV_TARGET_GIB=20 holds
-                                    # ~1.4M tokens, i.e. ~44 concurrent 32k requests or ~2.7 full
-                                    # 512k ones. 8-16 is safe for typical <=32k workloads; keep 4
+                                    # The KV pool bounds concurrency: fp8/KV_TARGET_GIB=22 measured
+                                    # 1,459,504 tokens here (~1.3M at 20), i.e. ~40 concurrent 32k
+                                    # requests or ~2.7 full 512k ones. 8-16 is safe for typical
+                                    # <=32k workloads; keep 4
                                     # only if you routinely serve near-full-context requests.
                                     # Watch vllm:num_requests_waiting on /metrics to see queueing.
 MAX_NUM_BATCHED_TOKENS=2048         # prefill chunk width. Raising this to 8192 buys ~11% prefill

--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,11 @@
 !/download.sh
 !/start.sh
 !/stop.sh
+!/qwen38-flash.service
 
 # --- launcher support and patch generators -----------------------------
+!/scripts/smoke-test.sh
+
 !/files/memwatch.sh
 !/files/build_ple_packed_table.py
 !/files/patch_ple_layer.py

--- a/README.md
+++ b/README.md
@@ -455,6 +455,33 @@ inside its reasoning, so `content` comes back empty on a perfectly healthy
 server. Gibberish in either field means the PLE path has regressed (bf16 IPC
 buffer or missing quant scales) — see the patch notes below.
 
+For a fuller post-launch check:
+
+```
+./scripts/smoke-test.sh                       # health, coherence, determinism, context, metrics
+PORT=9000 API_KEY=xyz ./scripts/smoke-test.sh # against a non-default port / authenticated server
+```
+
+The smoke test sends the same temperature-0 prompt twice and flags differing
+outputs — on GB10 the stock QSA top-k kernel is non-deterministic (drops
+candidates), so a failure there is a known stack property, not necessarily a
+broken deployment.
+
+## Monitoring
+
+vLLM exposes Prometheus metrics at `http://<host>:8888/metrics`. The series
+worth watching on this deployment:
+
+| Series | Why |
+|---|---|
+| `vllm:num_requests_waiting` | Non-zero means requests are queued behind `MAX_NUM_SEQS` — with the default 4, queueing is otherwise silent and looks exactly like a slow GPU |
+| `vllm:request_queue_time_seconds_*` | Time spent queued; rises before decode slows |
+| `vllm:gpu_cache_usage_perc` | KV pool occupancy; sustained near 1.0 means context pressure |
+| `vllm:generation_tokens_total` / `vllm:prompt_tokens_total` | Throughput; derive tok/s with `rate()` |
+
+Example: `rate(vllm:generation_tokens_total[1m])` for decode tok/s,
+`vllm:num_requests_waiting > 0` as a queueing alert.
+
 ## Layout
 
 - `download.sh` — fetches the checkpoint into the Hugging Face cache
@@ -472,6 +499,11 @@ buffer or missing quant scales) — see the patch notes below.
   first run. Edit the generators; edits to the generated files are overwritten.
 - `files/build_ple_packed_table.py` — one-time packed PLE table builder
   (27 GB output under `~/.cache/vllm/ple_cache/`, memory-mapped at runtime).
+- `scripts/smoke-test.sh` — post-launch verification (health, coherent
+  generation, temperature-0 determinism, served context, metrics endpoint).
+- `qwen38-flash.service` — optional systemd user unit: boots the server at
+  login (or at boot with `loginctl enable-linger`), restarts on failure,
+  and keeps the memwatch watchdog in the same lifecycle.
 
 Benchmarks are not part of this repo. The published prefill and decode numbers
 were measured with [sparkDash](https://github.com/MiaAI-Lab/sparkDash).

--- a/README.md
+++ b/README.md
@@ -462,10 +462,10 @@ For a fuller post-launch check:
 PORT=9000 API_KEY=xyz ./scripts/smoke-test.sh # against a non-default port / authenticated server
 ```
 
-The smoke test sends the same temperature-0 prompt twice and flags differing
-outputs — on GB10 the stock QSA top-k kernel is non-deterministic (drops
-candidates), so a failure there is a known stack property, not necessarily a
-broken deployment.
+The smoke test sends the same temperature-0 prompt twice and warns on
+differing outputs — on GB10 the stock QSA top-k kernel is non-deterministic
+(drops candidates, upstream vllm#51782), so a warning there is a known stack
+property (and a pass is luck, not proof), not a broken deployment.
 
 ## Monitoring
 
@@ -476,7 +476,7 @@ worth watching on this deployment:
 |---|---|
 | `vllm:num_requests_waiting` | Non-zero means requests are queued behind `MAX_NUM_SEQS` — with the default 4, queueing is otherwise silent and looks exactly like a slow GPU |
 | `vllm:request_queue_time_seconds_*` | Time spent queued; rises before decode slows |
-| `vllm:gpu_cache_usage_perc` | KV pool occupancy; sustained near 1.0 means context pressure |
+| `vllm:kv_cache_usage_perc` | KV pool occupancy; sustained near 1.0 means context pressure |
 | `vllm:generation_tokens_total` / `vllm:prompt_tokens_total` | Throughput; derive tok/s with `rate()` |
 
 Example: `rate(vllm:generation_tokens_total[1m])` for decode tok/s,

--- a/files/memwatch.sh
+++ b/files/memwatch.sh
@@ -22,13 +22,39 @@ NEAR_KB=$(( MIN_KB + 1048576 ))     # verbose logging band: floor + 1 GiB
 GRACE="${MEMWATCH_GRACE:-10}"       # seconds to let vLLM unlink its POSIX shm
 echo "$(date '+%F %T') watchdog start: container=$CONTAINER floor=${MIN_GIB}GiB" \
      "trigger=${CONSEC} consecutive samples"
+
+# Resolve the container's memory.current path once. The systemd-driver path
+# below does not exist with the cgroupfs driver, cgroup v1, or rootless
+# docker; probing at startup turns a silent "container=0MiB forever" into a
+# one-time warning.
+CID=$(docker inspect -f '{{.Id}}' "$CONTAINER" 2>/dev/null || echo "")
+CG_PATH=""
+for candidate in \
+    "/sys/fs/cgroup/system.slice/docker-${CID}.scope/memory.current" \
+    "/sys/fs/cgroup/system.slice/docker-${CID}.scope/memory.usage_in_bytes" \
+    "/sys/fs/cgroup/memory/docker/${CID}/memory.usage_in_bytes" \
+    "/sys/fs/cgroup/memory/system.slice/docker-${CID}.scope/memory.usage_in_bytes"; do
+    if [[ -n "$CID" && -r "$candidate" ]]; then
+        CG_PATH="$candidate"
+        break
+    fi
+done
+if [[ -z "$CG_PATH" ]]; then
+    echo "$(date '+%F %T') WARN: container cgroup memory file not readable; container= will log 0MiB (last resort: docker stats)"
+fi
+
 tick=0
 below=0
 while docker ps --format '{{.Names}}' | grep -q "^${CONTAINER}\$"; do
     avail=$(awk '/MemAvailable/{print $2}' /proc/meminfo)
     free=$(awk '/MemFree/{print $2}' /proc/meminfo)
     swapfree=$(awk '/SwapFree/{print $2}' /proc/meminfo)
-    cg=$(cat /sys/fs/cgroup/system.slice/docker-$(docker inspect -f '{{.Id}}' "$CONTAINER" 2>/dev/null).scope/memory.current 2>/dev/null || echo 0)
+    if [[ -n "$CG_PATH" ]]; then
+        cg=$(cat "$CG_PATH" 2>/dev/null || echo 0)
+    else
+        # ~100 ms per call; only when the timeline is actually printed below.
+        cg=0
+    fi
 
     if (( avail < MIN_KB )); then
         below=$(( below + 1 ))
@@ -50,6 +76,10 @@ while docker ps --format '{{.Names}}' | grep -q "^${CONTAINER}\$"; do
     fi
 
     if (( tick % 5 == 0 || avail < NEAR_KB )); then
+        if [[ -z "$CG_PATH" ]]; then
+            cg=$(docker stats --no-stream --format '{{.MemUsage}}' "$CONTAINER" 2>/dev/null | grep -oE '^[0-9.]+' | head -1)
+            cg=$(python3 -c "print(int(float('${cg:-0}')*2**20))" 2>/dev/null || echo 0)  # MiB -> KiB
+        fi
         echo "$(date '+%T') avail=$((avail/1024))MiB free=$((free/1024))MiB swapfree=$((swapfree/1024))MiB container=$((cg/1048576))MiB"
     fi
     tick=$((tick+1))

--- a/files/memwatch.sh
+++ b/files/memwatch.sh
@@ -40,20 +40,18 @@ for candidate in \
     fi
 done
 if [[ -z "$CG_PATH" ]]; then
-    echo "$(date '+%F %T') WARN: container cgroup memory file not readable; container= will log 0MiB (last resort: docker stats)"
+    echo "$(date '+%F %T') WARN: container cgroup memory file not readable; falling back to docker stats for the container= timeline"
 fi
 
 tick=0
 below=0
+cg=0
 while docker ps --format '{{.Names}}' | grep -q "^${CONTAINER}\$"; do
     avail=$(awk '/MemAvailable/{print $2}' /proc/meminfo)
     free=$(awk '/MemFree/{print $2}' /proc/meminfo)
     swapfree=$(awk '/SwapFree/{print $2}' /proc/meminfo)
     if [[ -n "$CG_PATH" ]]; then
         cg=$(cat "$CG_PATH" 2>/dev/null || echo 0)
-    else
-        # ~100 ms per call; only when the timeline is actually printed below.
-        cg=0
     fi
 
     if (( avail < MIN_KB )); then
@@ -77,8 +75,14 @@ while docker ps --format '{{.Names}}' | grep -q "^${CONTAINER}\$"; do
 
     if (( tick % 5 == 0 || avail < NEAR_KB )); then
         if [[ -z "$CG_PATH" ]]; then
-            cg=$(docker stats --no-stream --format '{{.MemUsage}}' "$CONTAINER" 2>/dev/null | grep -oE '^[0-9.]+' | head -1)
-            cg=$(python3 -c "print(int(float('${cg:-0}')*2**20))" 2>/dev/null || echo 0)  # MiB -> KiB
+            # ~100 ms per call, so only on printed ticks. docker stats prints
+            # e.g. "8.87GiB / 105GiB" — honour the unit suffix, and note it
+            # reports the working set while memory.current includes page
+            # cache, so the fallback reads lower than the cgroup path.
+            raw=$(docker stats --no-stream --format '{{.MemUsage}}' "$CONTAINER" 2>/dev/null)
+            cg=$(awk '{tok=$1; v=tok; gsub(/[A-Za-z]/,"",v); u=tok; gsub(/[0-9.]/,"",u);
+                       m=(u=="GiB"?2**30:(u=="MiB"?2**20:(u=="KiB"?2**10:(u=="B"?1:2**30))));
+                       printf "%d", v*m}' <<< "${raw:-0MiB}")
         fi
         echo "$(date '+%T') avail=$((avail/1024))MiB free=$((free/1024))MiB swapfree=$((swapfree/1024))MiB container=$((cg/1048576))MiB"
     fi

--- a/qwen38-flash.service
+++ b/qwen38-flash.service
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# systemd user unit for the single-Spark Qwen3.8-Flash-Next server.
+#
+# Install:
+#   mkdir -p ~/.config/systemd/user
+#   cp qwen38-flash.service ~/.config/systemd/user/
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now qwen38-flash
+#   loginctl enable-linger "$USER"        # start at boot without login
+#
+# start.sh stays in the foreground following logs until /health answers;
+# Type=simple + the long TimeoutStartSec accommodate that. The memwatch
+# watchdog is a child of start.sh, so supervision and watchdog share a
+# lifecycle. Restart=on-failure only: a clean ./stop.sh (or
+# systemctl --user stop) stays down.
+[Unit]
+Description=Qwen3.8-Flash-Next vLLM server (single Spark, TP=1)
+After=docker.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/qwen38-flash-next
+ExecStart=%h/qwen38-flash-next/start.sh
+ExecStop=%h/qwen38-flash-next/stop.sh
+# Weight load takes ~10-12 min; first boot additionally builds the ~27 GB
+# packed PLE table. Do not let systemd kill the start early.
+TimeoutStartSec=30min
+TimeoutStopSec=60s
+Restart=on-failure
+RestartSec=30s
+
+[Install]
+WantedBy=default.target

--- a/qwen38-flash.service
+++ b/qwen38-flash.service
@@ -8,18 +8,28 @@
 #   systemctl --user enable --now qwen38-flash
 #   loginctl enable-linger "$USER"        # start at boot without login
 #
-# start.sh stays in the foreground following logs until /health answers;
-# Type=simple + the long TimeoutStartSec accommodate that. The memwatch
-# watchdog is a child of start.sh, so supervision and watchdog share a
-# lifecycle. Restart=on-failure only: a clean ./stop.sh (or
-# systemctl --user stop) stays down.
+# start.sh launches the container, waits for /health, then EXITS 0 — the
+# container and the memwatch watchdog (nohup'd by start.sh) are the daemons.
+# Hence Type=oneshot + RemainAfterExit: the unit stays "active" after
+# start.sh returns, ExecStop brings the stack down, and a failed start.sh
+# (non-zero exit) marks the unit failed. Restart=on-failure covers start.sh
+# failing at boot (e.g. KV not yet released by another container); a crash
+# of the already-running container is vLLM's/docker's business — the
+# watchdog in start.sh handles the memory-emergency case.
+# NOTE: docker.service is a system unit; a user unit cannot order against or
+# require it. Docker autostart is a system-level assumption (it is enabled by
+# default on the DGX Spark OS). If you run this as a system unit instead
+# (/etc/systemd/system, with User=malvavisco and absolute paths), restore:
+#   After=docker.service network-online.target
+#   Requires=docker.service
 [Unit]
 Description=Qwen3.8-Flash-Next vLLM server (single Spark, TP=1)
-After=docker.service network-online.target
+After=network-online.target
 Wants=network-online.target
 
 [Service]
-Type=simple
+Type=oneshot
+RemainAfterExit=yes
 WorkingDirectory=%h/qwen38-flash-next
 ExecStart=%h/qwen38-flash-next/start.sh
 ExecStop=%h/qwen38-flash-next/stop.sh

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -14,9 +14,10 @@ EXPECT_LEN="${EXPECT_LEN:-}"        # set to 262144 or 524288 to assert context
 BASE="http://localhost:$PORT"
 AUTH=(); [[ -n "${API_KEY:-}" ]] && AUTH=(-H "Authorization: Bearer $API_KEY")
 
-pass=0; fail=0
+pass=0; fail=0; warn=0
 ok()   { echo "  PASS  $*"; pass=$((pass+1)); }
 bad()  { echo "  FAIL  $*"; fail=$((fail+1)); }
+note() { echo "  WARN  $*"; warn=$((warn+1)); }
 
 echo "== 1. health =="
 curl -s -m 5 -o /dev/null -w '%{http_code}' "$BASE/health" | grep -q 200 \
@@ -32,37 +33,53 @@ echo "== 3. coherent generation (temp 0) =="
 RESP=$(curl -s -m 120 "${AUTH[@]}" -H 'Content-Type: application/json' "$BASE/v1/chat/completions" -d "{
   \"model\": \"$MODEL\", \"temperature\": 0, \"max_tokens\": 256,
   \"messages\": [{\"role\":\"user\",\"content\":\"What is 17 * 23? Think step by step, then give the final number.\"}]}")
-ANSWER=$(echo "$RESP" | python3 -c 'import json,sys; print(json.load(sys.stdin)["choices"][0]["message"]["content"] or "")' 2>/dev/null)
+# This model reasons first in a `reasoning` field; content may lag behind.
+ANSWER=$(echo "$RESP" | python3 -c 'import json,sys
+m = json.load(sys.stdin)["choices"][0]["message"]
+print((m.get("reasoning") or "") + "\n" + (m.get("content") or ""))' 2>/dev/null)
 echo "$ANSWER" | grep -q "391" && ok "17*23=391 answered correctly" || bad "answer missing 391: ${ANSWER:0:200}"
 
 echo "== 4. determinism (temp 0, two runs) =="
 PROMPT='{"model":"'$MODEL'","temperature":0,"max_tokens":128,"messages":[{"role":"user","content":"List the first 8 prime numbers."}]}'
-R1=$(curl -s -m 120 "${AUTH[@]}" -H 'Content-Type: application/json' "$BASE/v1/chat/completions" -d "$PROMPT" | python3 -c 'import json,sys; print(json.load(sys.stdin)["choices"][0]["message"]["content"] or "")' 2>/dev/null)
-R2=$(curl -s -m 120 "${AUTH[@]}" -H 'Content-Type: application/json' "$BASE/v1/chat/completions" -d "$PROMPT" | python3 -c 'import json,sys; print(json.load(sys.stdin)["choices"][0]["message"]["content"] or "")' 2>/dev/null)
+R1=$(curl -s -m 120 "${AUTH[@]}" -H 'Content-Type: application/json' "$BASE/v1/chat/completions" -d "$PROMPT" | python3 -c 'import json,sys
+m=json.load(sys.stdin)["choices"][0]["message"]; print((m.get("reasoning") or "")+(m.get("content") or ""))' 2>/dev/null)
+R2=$(curl -s -m 120 "${AUTH[@]}" -H 'Content-Type: application/json' "$BASE/v1/chat/completions" -d "$PROMPT" | python3 -c 'import json,sys
+m=json.load(sys.stdin)["choices"][0]["message"]; print((m.get("reasoning") or "")+(m.get("content") or ""))' 2>/dev/null)
 if [[ -n "$R1" && "$R1" == "$R2" ]]; then
     ok "identical outputs at temperature 0"
 else
-    bad "outputs differ at temperature 0 (GB10 QSA top-k is non-deterministic — see issue #7)"
+    # Known stack property, not a deployment failure: the stock GB10 QSA
+    # top-k kernel is non-deterministic (drops candidates, upstream
+    # vllm#51782). Flaky in both directions — a pass does not prove the
+    # kernel is deterministic either.
+    note "outputs differ at temperature 0 (known GB10 QSA top-k non-determinism — see issue #7)"
 fi
 
 echo "== 5. decode speed (real answer, not ignore_eos) =="
+# Client-side wall clock; fine for a smoke check, not a benchmark — MTP
+# acceptance is content-dependent, so treat the number as a range. Healthy
+# single-stream decode on this kit is roughly 25-40 tok/s.
+T0=$(date +%s.%N)
 OUT=$(curl -s -m 300 "${AUTH[@]}" -H 'Content-Type: application/json' "$BASE/v1/chat/completions" -d "{
   \"model\": \"$MODEL\", \"temperature\": 0, \"max_tokens\": 400,
   \"messages\": [{\"role\":\"user\",\"content\":\"Write a 350-word travel guide to Lisbon.\"}]}")
-echo "$OUT" | python3 -c '
+T1=$(date +%s.%N)
+RATE=$(echo "$OUT" | python3 -c '
 import json, sys
 d = json.load(sys.stdin)
-u = d["usage"]
-ct = u["completion_tokens"]
-# vLLM does not report wall time; measure client-side is unreliable, so use
-# the server-side usage only and ask the caller to compare against ~25-40 tok/s.
-print(f"  completion_tokens={ct}")
-' 2>/dev/null || bad "no usage in response"
+print(d["usage"]["completion_tokens"])' 2>/dev/null)
+if [[ -n "$RATE" && "$RATE" -gt 0 ]]; then
+    TPS=$(python3 -c "print(f'{$RATE / ($T1 - $T0):.1f}')")
+    echo "  completion_tokens=$RATE in $(python3 -c "print(f'{$T1-$T0:.1f}')")s -> ${TPS} tok/s"
+    python3 -c "import sys; sys.exit(0 if $RATE / ($T1 - $T0) >= 15 else 1)"         && ok "decode ${TPS} tok/s (>=15)" || bad "decode ${TPS} tok/s — suspiciously slow"
+else
+    bad "no completion tokens in response"
+fi
 
 echo "== 6. metrics endpoint =="
 curl -s -m 5 "$BASE/metrics" | grep -q "vllm:" \
     && ok "/metrics exposes vllm: series" || bad "/metrics missing vllm: series"
 
 echo ""
-echo "== $pass passed, $fail failed =="
+echo "== $pass passed, $fail failed, $warn warnings =="
 exit $((fail > 0))

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# smoke-test.sh — verify a running server actually works: health, coherent
+# generation, determinism at temperature 0, decode speed, served context.
+#
+# Usage:
+#   ./scripts/smoke-test.sh                      # localhost:8888, no auth
+#   PORT=9000 API_KEY=xyz ./scripts/smoke-test.sh
+set -uo pipefail
+
+PORT="${PORT:-8888}"
+MODEL="${SERVED_MODEL_NAME:-qwen3.8-flash-next}"
+EXPECT_LEN="${EXPECT_LEN:-}"        # set to 262144 or 524288 to assert context
+BASE="http://localhost:$PORT"
+AUTH=(); [[ -n "${API_KEY:-}" ]] && AUTH=(-H "Authorization: Bearer $API_KEY")
+
+pass=0; fail=0
+ok()   { echo "  PASS  $*"; pass=$((pass+1)); }
+bad()  { echo "  FAIL  $*"; fail=$((fail+1)); }
+
+echo "== 1. health =="
+curl -s -m 5 -o /dev/null -w '%{http_code}' "$BASE/health" | grep -q 200 \
+    && ok "/health 200" || { bad "/health not 200 — is the server up?"; exit 1; }
+
+echo "== 2. model metadata =="
+LEN=$(curl -s -m 5 "${AUTH[@]}" "$BASE/v1/models" | python3 -c \
+    'import json,sys; print(json.load(sys.stdin)["data"][0]["max_model_len"])' 2>/dev/null || echo 0)
+[[ "$LEN" -gt 0 ]] && ok "max_model_len=$LEN" || bad "could not read max_model_len (auth needed? set API_KEY)"
+[[ -n "$EXPECT_LEN" && "$LEN" != "$EXPECT_LEN" ]] && bad "expected max_model_len=$EXPECT_LEN, got $LEN"
+
+echo "== 3. coherent generation (temp 0) =="
+RESP=$(curl -s -m 120 "${AUTH[@]}" -H 'Content-Type: application/json' "$BASE/v1/chat/completions" -d "{
+  \"model\": \"$MODEL\", \"temperature\": 0, \"max_tokens\": 256,
+  \"messages\": [{\"role\":\"user\",\"content\":\"What is 17 * 23? Think step by step, then give the final number.\"}]}")
+ANSWER=$(echo "$RESP" | python3 -c 'import json,sys; print(json.load(sys.stdin)["choices"][0]["message"]["content"] or "")' 2>/dev/null)
+echo "$ANSWER" | grep -q "391" && ok "17*23=391 answered correctly" || bad "answer missing 391: ${ANSWER:0:200}"
+
+echo "== 4. determinism (temp 0, two runs) =="
+PROMPT='{"model":"'$MODEL'","temperature":0,"max_tokens":128,"messages":[{"role":"user","content":"List the first 8 prime numbers."}]}'
+R1=$(curl -s -m 120 "${AUTH[@]}" -H 'Content-Type: application/json' "$BASE/v1/chat/completions" -d "$PROMPT" | python3 -c 'import json,sys; print(json.load(sys.stdin)["choices"][0]["message"]["content"] or "")' 2>/dev/null)
+R2=$(curl -s -m 120 "${AUTH[@]}" -H 'Content-Type: application/json' "$BASE/v1/chat/completions" -d "$PROMPT" | python3 -c 'import json,sys; print(json.load(sys.stdin)["choices"][0]["message"]["content"] or "")' 2>/dev/null)
+if [[ -n "$R1" && "$R1" == "$R2" ]]; then
+    ok "identical outputs at temperature 0"
+else
+    bad "outputs differ at temperature 0 (GB10 QSA top-k is non-deterministic — see issue #7)"
+fi
+
+echo "== 5. decode speed (real answer, not ignore_eos) =="
+OUT=$(curl -s -m 300 "${AUTH[@]}" -H 'Content-Type: application/json' "$BASE/v1/chat/completions" -d "{
+  \"model\": \"$MODEL\", \"temperature\": 0, \"max_tokens\": 400,
+  \"messages\": [{\"role\":\"user\",\"content\":\"Write a 350-word travel guide to Lisbon.\"}]}")
+echo "$OUT" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+u = d["usage"]
+ct = u["completion_tokens"]
+# vLLM does not report wall time; measure client-side is unreliable, so use
+# the server-side usage only and ask the caller to compare against ~25-40 tok/s.
+print(f"  completion_tokens={ct}")
+' 2>/dev/null || bad "no usage in response"
+
+echo "== 6. metrics endpoint =="
+curl -s -m 5 "$BASE/metrics" | grep -q "vllm:" \
+    && ok "/metrics exposes vllm: series" || bad "/metrics missing vllm: series"
+
+echo ""
+echo "== $pass passed, $fail failed =="
+exit $((fail > 0))


### PR DESCRIPTION
Fixes the remaining half of #13, plus #14, #18, #19. All changes are confined to files **not** touched by #21, so the two PRs merge cleanly in either order.

Everything here was reviewed and **tested live against a running 512k YaRN deployment of this kit** before opening — the commit history shows the bugs that self-review caught (unit mismatches, systemd unit type, smoke-test parsing), fixed in follow-up commits on the branch.

## #13 (remaining half) — memwatch cgroup fallback
The SIGKILL→`docker stop` half already landed in c79f765. This resolves the container's cgroup memory file **once at startup** across cgroup v1/v2 and systemd/cgroupfs driver layouts, warns once if unreadable, and falls back to `docker stats` for the container-RSS timeline — instead of logging `container=0MiB` forever on non-systemd-docker hosts. The fallback is unit-aware (`8.87GiB` vs `512MiB`) and byte-normalized to match `memory.current`. Both paths verified live: cgroup reports 19743 MiB (page-cache inclusive), `docker stats` 9081 MiB (working set) — the difference is documented in a comment.

## #18 — smoke test + monitoring docs
New `scripts/smoke-test.sh`: health, coherent temperature-0 generation (reads both `reasoning` and `content`, since this model answers in `reasoning` first), temperature-0 determinism across two runs, served `max_model_len` vs an expected value, wall-clock decode tok/s, and the `/metrics` endpoint. Final live result:

```
== 1. health ==            PASS
== 2. model metadata ==    PASS  max_model_len=524288
== 3. coherent generation  PASS  17*23=391
== 4. determinism ==       WARN  outputs differ at temperature 0
== 5. decode speed ==      PASS  29.8 tok/s
== 6. metrics endpoint ==  PASS
== 5 passed, 0 failed, 1 warning ==  (exit 0)
```

The determinism check is a **warning, not a failure**: live testing showed it flip-flops between runs — the known GB10 QSA top-k non-determinism (#7, upstream vllm#51782) — so the exit code only means "deployment broken".

README gains a **Monitoring** section documenting `/metrics` with the series worth watching, verified against the live server: `vllm:num_requests_waiting` (silent queueing behind MAX_NUM_SEQS), `vllm:request_queue_time_seconds_*`, `vllm:kv_cache_usage_perc`, `vllm:generation_tokens_total`.

## #19 — MAX_NUM_SEQS benchmarking trap documented
`.env.sample` comment-only change: 4 seqs flatlines aggregate tok/s in a way indistinguishable from GPU saturation (~86 tok/s @4 vs >260 tok/s @48 streams measured on this hardware), plus the KV-pool math for raising it (measured 1,459,504 tokens at fp8/KV_TARGET_GIB=22 ⇒ ~40 concurrent 32k requests). The default stays 4 pending a concurrency sweep on the KV budget — see #4.

## #14 — systemd user unit
New `qwen38-flash.service`: `Type=oneshot` + `RemainAfterExit=yes` (start.sh exits 0 once /health answers; the container and watchdog are the daemons), `Restart=on-failure` covers start.sh failing at boot, 30-min start timeout for weight load + first-boot PLE table build. Verified with `systemd-analyze --user verify` on the target host — note `After=/Requires=docker.service` is deliberately absent: a user unit cannot order against a system unit (a comment explains how to restore it for a system-unit install). Also allowlisted in `.gitignore` together with the smoke script.
