### PR TITLE
Fix 64KB-page kernel load hang and OOM via cloned lazy yields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 !/files/patch_ple_offload.py
 !/files/patch_qsa_fp8_kv.py
 !/files/patch_mtp_draft_vocab.py
+!/files/patch_safetensors_clone.py
 # builds the reduced draft vocabulary the MTP patch reads. Its output is a
 # generated artifact and lives in ~/.cache/vllm/draft_vocab/, not here.
 !/files/build_draft_vocab.py

--- a/files/patch_safetensors_clone.py
+++ b/files/patch_safetensors_clone.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+import os, sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ORIG = os.path.join(HERE, "weight_utils_patched.py.orig")
+OUT = os.path.join(HERE, "weight_utils_patched.py")
+
+def patch() -> None:
+    src = open(ORIG).read()
+    old_code = (
+        "                    param = f.get_tensor(name)\n"
+        "                    yield name, param\n"
+    )
+    new_code = (
+        "                    param = f.get_tensor(name)\n"
+        "                    yield name, param.clone()\n"
+    )
+    if src.count(old_code) != 1:
+        raise AssertionError(f"weight_utils: anchor missing or not unique (count={src.count(old_code)})")
+    src = src.replace(old_code, new_code, 1)
+    open(OUT, "w").write(src)
+    print("ok", OUT)
+
+if __name__ == "__main__":
+    if not os.path.isfile(ORIG):
+        print(f"ERROR: missing {ORIG}", file=sys.stderr)
+        sys.exit(1)
+    patch()

--- a/start.sh
+++ b/start.sh
@@ -156,14 +156,14 @@ KV_TARGET_GIB="${KV_TARGET_GIB:-8.0}"
 # MemTotal - HOST_RESERVE_GIB whatever KV_TARGET_GIB asks for. See SAFETY above
 # for what the 26 GiB covers. Raise it by 2 GiB steps if the watchdog log shows
 # MemAvailable idling under ~9 GiB; do not lower it to buy KV.
-HOST_RESERVE_GIB="${HOST_RESERVE_GIB:-26}"
+HOST_RESERVE_GIB="${HOST_RESERVE_GIB:-28}"
 # Host-side memory the container needs beyond the GPU budget: three Python
 # processes, pinned staging buffers, CPU-side torch, page cache slack.
 HOST_SLACK_GIB="${HOST_SLACK_GIB:-10.0}"
 # Never let the container cgroup cap come within this much of the pool.
 OS_RESERVE_GIB="${OS_RESERVE_GIB:-16.0}"
 # Watchdog: stop the container if host MemAvailable stays below this (GiB) ...
-MEMWATCH_MIN_GIB="${MEMWATCH_MIN_GIB:-6}"
+MEMWATCH_MIN_GIB="${MEMWATCH_MIN_GIB:-4}"
 # ... or MemFree stays below this. The NVIDIA driver refuses allocations
 # (NV_ERR_NO_MEMORY) at MemFree ~3 GiB while MemAvailable still reads 6+.
 MEMWATCH_MIN_FREE_GIB="${MEMWATCH_MIN_FREE_GIB:-2}"
@@ -447,6 +447,7 @@ fi
 VLLM_PKG=/usr/local/lib/python3.12/dist-packages/vllm
 PLE_PKG="$VLLM_PKG/models/qwen3_8_flash_next/nvidia/ple_layer.py"
 MODELOPT_PKG="$VLLM_PKG/model_executor/layers/quantization/modelopt.py"
+WEIGHT_UTILS_PKG="$VLLM_PKG/model_executor/model_loader/weight_utils.py"
 QSA_OPS_PKG="$VLLM_PKG/models/qwen3_8_flash_next/nvidia/ops/qsa.py"
 QSA_NVIDIA_PKG="$VLLM_PKG/models/qwen3_8_flash_next/nvidia/qsa.py"
 MTP_PKG="$VLLM_PKG/models/qwen3_8_flash_next/nvidia/mtp.py"
@@ -469,6 +470,11 @@ PATCHED_PLE="$SCRIPT_DIR/files/ple_layer_patched.py"
 extract "$PLE_PKG" "$SCRIPT_DIR/files/ple_layer_patched.py.orig"
 python3 "$SCRIPT_DIR/files/patch_ple_layer.py"
 [[ -f "$PATCHED_PLE" ]] || err "PLE patch missing after patch_ple_layer.py"
+
+PATCHED_WEIGHT_UTILS="$SCRIPT_DIR/files/weight_utils_patched.py"
+extract "$WEIGHT_UTILS_PKG" "$SCRIPT_DIR/files/weight_utils_patched.py.orig"
+python3 "$SCRIPT_DIR/files/patch_safetensors_clone.py"
+[[ -f "$PATCHED_WEIGHT_UTILS" ]] || err "weight_utils patch missing after patch_safetensors_clone.py"
 
 PATCHED_MODELOPT="$SCRIPT_DIR/files/modelopt_patched.py"
 extract "$MODELOPT_PKG" "$SCRIPT_DIR/files/modelopt_patched.py.orig"
@@ -628,6 +634,7 @@ docker run \\
     ${HF_TOKEN:+-e HF_TOKEN=$HF_TOKEN} \\
     -v $PATCHED_PLE:$PLE_PKG:ro \\
     -v $PATCHED_MODELOPT:$MODELOPT_PKG:ro \\
+    -v $PATCHED_WEIGHT_UTILS:$WEIGHT_UTILS_PKG:ro \\
     -v $PATCHED_QSA_OPS:$QSA_OPS_PKG:ro \\
     -v $PATCHED_QSA_NVIDIA:$QSA_NVIDIA_PKG:ro \\
     -v $PATCHED_MTP:$MTP_PKG:ro \\


### PR DESCRIPTION
### Summary of Changes

On ARM64 kernels running with 64KB page sizes (such as DGX OS on NVIDIA DGX Spark / GB10), loading unaligned safetensors via `safetensors.torch.load_file` causes severe DMA transfer stalls (driver spinlock inside kernel page-table sync). This manifests as the loader hanging indefinitely during the language model weight loading phase, or taking hours to finish.

This PR introduces an in-place patch to vLLM's `weight_utils.py` and relaxes watchdog thresholds to ensure reliable single-node initialization:

1. **Lazy Tensor Cloning (`files/patch_safetensors_clone.py`)**:
   - Hooks into `safetensors_weights_iterator` to yield `tensor.clone()` rather than the raw mmap-backed slice.
   - Allocates the tensor into standard, 64KB-aligned anonymous heap memory right before host-to-device DMA, completely eliminating the kernel alignment stall.
   - Evaluates lazily (one tensor at a time), keeping memory overhead minimal (peak ~1.5 GiB buffer) without triggering unified memory spills. Loading completes in ~82 seconds.

2. **Launcher & Watchdog Budgeting (`start.sh`)**:
   - Integrated automatic patching of `weight_utils.py` via container source extraction.
   - Raised default `HOST_RESERVE_GIB` from 26 to 28 GiB and lowered `MEMWATCH_MIN_GIB` to 4 GiB, preventing spurious watchdog kills during temporary PLE table mmap staging.

3. **Allowlist Update (`.gitignore`)**:
   - Included `files/patch_safetensors_clone.py` in the allowlist.

### Verification
- Environment: NVIDIA DGX Spark (Dell Pro Max GB10), Ubuntu 24.04 LTS (kernel 6.17 ARM64 64KB pages), sm_121.
- Results: Reduced weight loading time from infinite hang / stalls down to 82 seconds. Verified inference stability under concurrent multi-turn requests without watchdog termination.

### Additional Context & Benchmarks
For detailed troubleshooting logs, GDB backtraces, and full verification write-up, see:
https://mcsm.jp/documents/qwen38_flash_next_single_dgx_spark/