### PR TITLE
Opt-in GB10 kernels: +5.5% solo code tok/s, ~6% faster prefill

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -16,6 +16,9 @@ YARN=0                              # 0 = native rope (uses MAX_MODEL_LEN), 1 = 
 MAX_MODEL_LEN=262144                # context at YARN=0; cannot exceed the native 262144
 YARN_MAX_MODEL_LEN=524288           # context at YARN=1; ignored when YARN=0. Ceiling 524288
 MTP_NUM_SPECULATIVE_TOKENS=3        # 0 disables MTP (saves 1.5 GiB)
+MTP_DRAFT_HEAD_FP8=0                # experimental GB10 W8A16 reduced draft head; target is unchanged.
+                                    # Requires MTP_DRAFT_VOCAB (see files/build_draft_vocab.py).
+                                    # Adds ~160 MiB of buffers for a 65,536-token vocabulary.
 KV_TARGET_GIB=20                    # KV wish, GiB. A wish, not a grant: the GPU budget is capped at
                                     # MemTotal - HOST_RESERVE_GIB, and start.sh prints "KV target X
                                     # reduced to Y" when the cap binds. It binds here. Measured

--- a/.env.sample
+++ b/.env.sample
@@ -46,6 +46,9 @@ MAMBA_SSM_CACHE_DTYPE=bfloat16      # dtype of the GDN recurrent (SSM) state. Th
                                     # with acceptance unchanged; needles 15/15 at 32k, same as
                                     # float32; 4-turn continuation shows no recurrence drift.
                                     # Empty keeps the checkpoint's float32.
+GDN_PREFILL_BACKEND=auto             # auto preserves the image's Triton/FLA choice on GB10.
+                                    # flashinfer opts into the source-checked SM121 prefill patch.
+                                    # Decode kernels and state-cache dtype are unchanged.
 MAX_NUM_SEQS=4                      # concurrent sequences (see README for KV headroom). The KV
                                     # pool holds 3.79x a full 262k request, so this is the
                                     # long-context limit, not a throughput knob. Aggregate decode

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@
 
 # --- launcher support and patch generators -----------------------------
 !/files/memwatch.sh
+!/files/patch_gdn_sm121.py
+!/files/test_gdn_sm121.py
+!/bench/gdn_sm121_preflight.py
+!/docs/sm121-gdn-prefill.md
 !/files/build_ple_packed_table.py
 !/files/patch_ple_layer.py
 !/files/patch_modelopt_mxfp8.py

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@
 # --- top level ---------------------------------------------------------
 !/.gitignore
 !/LICENSE
+!/LICENSES/Apache-2.0.txt
+!/THIRD_PARTY_NOTICES.md
 !/README.md
 !/CHANGELOG.md
 # the serving profile. /.env itself stays ignored: it may hold HF_TOKEN.
@@ -31,6 +33,12 @@
 !/files/test_gdn_sm121.py
 !/bench/gdn_sm121_preflight.py
 !/docs/sm121-gdn-prefill.md
+!/files/patch_mtp_fp8_head.py
+!/files/spark_mtp_fp8_head.py
+!/files/test_mtp_fp8_head.py
+!/bench/mtp_fp8_head_preflight.py
+!/docs/sm121-mtp-fp8-head.md
+!/docs/sm121-code-benchmarks.md
 !/files/build_ple_packed_table.py
 !/files/patch_ple_layer.py
 !/files/patch_modelopt_mxfp8.py

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -636,6 +636,26 @@ default was held to, and it is one night's evidence rather than a graded task
 eval. Set `MAMBA_SSM_CACHE_DTYPE=` empty to go back to the checkpoint's
 float32.
 
+### Optional SM121 prefill and draft-head kernels
+
+Two independent opt-ins; defaults preserve the existing paths:
+
+```sh
+GDN_PREFILL_BACKEND=auto   # flashinfer: source-checked GB10 prefill backend
+MTP_DRAFT_HEAD_FP8=0       # 1: experimental FP8 reduced MTP head; requires MTP_DRAFT_VOCAB
+```
+
+On a separate single-Spark coding A/B (native 262k, MTP3, 65k draft vocabulary,
+32-GiB host reserve), both enabled gave **53.81→56.76 solo decode tok/s
+(+5.5%)** and about **6% faster cold code prefill**. Four-stream batch
+throughput was effectively flat; faster tokens did not consistently shorten
+completed-task latency. Functional scores varied (42/44 baseline, 40/44 both),
+so FP8 stays experimental rather than default-on. It adds 0.1565 GiB at 65k
+vocabulary; neither switch lowers the host reserve. See the
+[four-way comparison and caveats](docs/sm121-code-benchmarks.md),
+[GDN details](docs/sm121-gdn-prefill.md), and
+[FP8 details](docs/sm121-mtp-fp8-head.md) before enabling them.
+
 ### PLE mmap access pattern
 
 The packed PLE table is advised `MADV_RANDOM` (in `patch_ple_offload.py`).
@@ -851,6 +871,10 @@ sparkDash's own figures include any other traffic on the port.
 
 ## Credits
 
+- **[Gabriel Olympie (@gabrielolympie)](https://github.com/gabrielolympie/sglang-flashnext-sm120)**
+  — the original SM120 optimization work that inspired the GDN investigation
+  and supplied the Apache-2.0 kernel adapted for the optional GB10 FP8 draft
+  head. See [source attribution and modifications](THIRD_PARTY_NOTICES.md).
 - **Qwen / Alibaba** — [Qwen3.8-Flash-Next](https://huggingface.co/Qwen/Qwen3.8-Flash-Next),
   the base model everything here derives from.
 - **MiaAI Lab** — the single-DGX-Spark NVFP4 recipe and
@@ -870,8 +894,9 @@ sparkDash's own figures include any other traffic on the port.
 Copyright (C) 2026 MiaAI Lab (https://x.com/MiaAI_lab)
 
 Licensed under the **GNU Affero General Public License v3.0 or later**
-(AGPL-3.0-or-later). See `LICENSE`. Every source file carries an
-`SPDX-License-Identifier: AGPL-3.0-or-later` header.
+(AGPL-3.0-or-later). See `LICENSE`. Source files identify their license with
+SPDX headers. The optional SM121 helpers/tests marked Apache-2.0 retain that
+license; see `LICENSES/Apache-2.0.txt` and `THIRD_PARTY_NOTICES.md`.
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU Affero General Public License as published by the Free

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,24 @@
+# Third-party kernel attribution
+
+The Triton W8A16 kernel in `files/spark_mtp_fp8_head.py` is adapted from
+**Gabriel Olympie (@gabrielolympie)** and contributors' work in
+[sglang-flashnext-sm120](https://github.com/gabrielolympie/sglang-flashnext-sm120/tree/67d2f9234fa45ae1339f0d53cd37cb695e9c6493),
+pinned at commit `67d2f9234fa45ae1339f0d53cd37cb695e9c6493`:
+
+- `patches/0004-sm120-lowm-triton-gemm.patch`
+- `patches/0005-sm120-fp8-weight-only.patch`
+
+Those kernels carry `SPDX-License-Identifier: Apache-2.0`. The adapted helper
+retains that identifier; a copy of the license is provided in
+[LICENSES/Apache-2.0.txt](LICENSES/Apache-2.0.txt). The recipe's existing
+top-level license is unchanged.
+
+Raymond Lucke's adaptation restricts the optimization to vLLM's reduced MTP
+draft head, uses module-owned nonpersistent buffers instead of a global pointer
+cache, and tunes a split-free N=32/K=256/stages=3 tactic for SM121/GB10. Target
+weights and rejection sampling are not changed.
+
+The investigation into FlashInfer GDN prefill was also inspired by Gabriel's
+prefill-state work. That resolver patch uses vLLM's existing FlashInfer adapter;
+it is not a transplant of the SGLang runtime. Thanks to Gabriel for sharing
+the original optimization work and measurements.

--- a/bench/gdn_sm121_preflight.py
+++ b/bench/gdn_sm121_preflight.py
@@ -1,0 +1,106 @@
+"""SM121 FlashInfer GDN vs installed FLA: numerics, state continuation, timing.
+
+Synthetic inputs with the live Qwen geometry (Hq=16, Hv=48, K=V=128),
+including ragged batches, nonzero BF16 initial states, and resumed chunks.
+Runs outside the serving engine. Requires Qwen stopped to leave memory headroom.
+"""
+import json
+import statistics
+import time
+
+import torch
+from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
+    fi_chunk_gated_delta_rule as fi,
+    fla_chunk_gated_delta_rule as fla,
+)
+
+
+def emit(row):
+    print(json.dumps(row), flush=True)
+
+
+def errors(actual, reference):
+    a, b = actual.float(), reference.float()
+    rms = b.square().mean().sqrt().clamp_min(1e-8)
+    return {"finite": bool(torch.isfinite(a).all()),
+            "relative_rmse": float((a-b).square().mean().sqrt()/rms),
+            "max_absolute": float((a-b).abs().max()),
+            "reference_rms": float(rms)}
+
+
+def timed(fn):
+    for _ in range(3):
+        fn()
+    torch.cuda.synchronize()
+    samples = []
+    # Includes adapter/copies and launch overhead, unlike just timing the core.
+    for _ in range(9):
+        start, end = torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(8):
+            fn()
+        end.record()
+        end.synchronize()
+        samples.append(start.elapsed_time(end)/8)
+    return statistics.median(samples)
+
+
+def make(lengths, seed, g_scale=1):
+    torch.manual_seed(seed)
+    total = sum(lengths)
+    device = "cuda"
+    def r(*shape):
+        return torch.randn(*shape, device=device, dtype=torch.bfloat16)
+    cu = torch.tensor([0] + list(torch.tensor(lengths).cumsum(0).tolist()), device=device, dtype=torch.int32)
+    return dict(q=r(1, total, 16, 128), k=r(1, total, 16, 128), v=r(1, total, 48, 128),
+        g=-torch.rand(1, total, 48, device=device)*g_scale,
+        beta=torch.rand(1, total, 48, device=device, dtype=torch.bfloat16),
+        initial_state=r(len(lengths), 48, 128, 128)*0.1,
+        output_final_state=True, cu_seqlens=cu, use_qk_l2norm_in_kernel=True)
+
+
+@torch.inference_mode()
+def main():
+    assert torch.cuda.get_device_capability() == (12, 1)
+    emit({"begin": True, "torch": torch.__version__, "device": torch.cuda.get_device_name(),
+          "time": time.time()})
+    for index, lengths in enumerate(([31], [65], [1664], [2048], [17, 63, 129, 257], [512]*4)):
+        for g_scale in (1, 0.01):
+            inputs = make(lengths, 610+index, g_scale)
+            started = time.monotonic()
+            ref_o, ref_s = fla(**inputs)
+            out, state = fi(**inputs)
+            torch.cuda.synchronize()
+            eo, es = errors(out, ref_o), errors(state, ref_s)
+            row = {"lengths": lengths, "g_scale": g_scale, "output_error": eo, "state_error": es,
+                   "first_call_s": time.monotonic()-started}
+            # A relative-RMS guard, not arbitrary elementwise allclose near zeros.
+            row["passed"] = all(e["finite"] and e["relative_rmse"] < .03 for e in (eo, es))
+            if g_scale == 1:
+                row.update(fla_ms=timed(lambda: fla(**inputs)), fi_ms=timed(lambda: fi(**inputs)))
+            emit(row)
+            assert row["passed"], "GDN output/state failed numerical guard"
+            del inputs, ref_o, ref_s, out, state
+    # Two consecutive 1664-token cache chunks with BF16 state write-back.
+    inputs = make([3328], 777, .01)
+    full_o, full_s = fla(**inputs)
+    states = {"fla": inputs["initial_state"], "fi": inputs["initial_state"]}
+    outputs = {"fla": [], "fi": []}
+    for start in (0, 1664):
+        for name, fn in (("fla", fla), ("fi", fi)):
+            kwargs = {**inputs, "initial_state": states[name].to(torch.bfloat16),
+                "cu_seqlens": torch.tensor([0, 1664], device="cuda", dtype=torch.int32)}
+            for key in ("q", "k", "v", "g", "beta"):
+                kwargs[key] = inputs[key][:, start:start+1664].contiguous()
+            o, states[name] = fn(**kwargs)
+            outputs[name].append(o)
+    eo = errors(torch.cat(outputs["fi"], 1), torch.cat(outputs["fla"], 1))
+    es = errors(states["fi"], states["fla"])
+    passed = all(e["finite"] and e["relative_rmse"] < .03 for e in (eo, es))
+    emit({"continuation": True, "output_error": eo, "state_error": es,
+          "fla_split_vs_full": errors(torch.cat(outputs["fla"], 1), full_o), "passed": passed})
+    assert passed
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/mtp_fp8_head_preflight.py
+++ b/bench/mtp_fp8_head_preflight.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Actual-checkpoint FP8 draft-head tests. Run with the LLM stopped.
+
+Use the serving image in a bounded, network-disabled disposable container.
+Make files/spark_mtp_fp8_head.py importable (e.g. PYTHONPATH=/recipe/files).
+Mount the complete HF cache tree read-only so snapshot symlinks resolve.
+"""
+import argparse
+import json
+from pathlib import Path
+from types import SimpleNamespace
+import statistics
+
+import torch
+from safetensors import safe_open
+
+import spark_mtp_fp8_head as candidate
+
+
+def error(actual, reference):
+    a, b = actual.float(), reference.float()
+    return {"finite": bool(torch.isfinite(a).all()),
+            "relative_rmse": float((a-b).square().mean().sqrt()/b.square().mean().sqrt().clamp_min(1e-8)),
+            "max_absolute": float((a-b).abs().max())}
+
+
+def graph_ms(fn, weights):
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for w in weights: fn(w)
+    torch.cuda.current_stream().wait_stream(stream)
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        outputs = [fn(w) for w in weights]
+    for _ in range(3): graph.replay()
+    samples = []
+    for _ in range(9):
+        a,b = torch.cuda.Event(enable_timing=True),torch.cuda.Event(enable_timing=True)
+        a.record()
+        for _ in range(8): graph.replay()
+        b.record()
+        b.synchronize()
+        samples.append(a.elapsed_time(b)/8/len(weights))
+    return statistics.median(samples)
+
+
+@torch.inference_mode()
+def main(snapshot, vocab):
+    assert torch.cuda.get_device_capability() == (12,1)
+    torch.manual_seed(853)
+    torch.set_float32_matmul_precision("highest")
+    index = json.loads((snapshot / "model.safetensors.index.json").read_text())
+    ids = torch.tensor(sorted({int(x) for x in vocab.read_text().splitlines() if x.strip()}))
+    with safe_open(snapshot / index["weight_map"]["lm_head.weight"], framework="pt", device="cpu") as handle:
+        full = handle.get_tensor("lm_head.weight")
+        assert ids.numel() and int(ids.min()) >= 0 and int(ids.max()) < full.shape[0]
+        weight = full.index_select(0,ids).to("cuda")
+    original = weight.clone()
+    packed,scale = candidate.quantize_rows(weight)
+    assert torch.equal(weight,original)
+    count = max(4, (128*1024**2 + packed.numel()-1)//packed.numel())
+    weights = [weight] + [weight.clone() for _ in range(count-1)]
+    fp8s = [(packed,scale)] + [(packed.clone(),scale.clone()) for _ in range(count-1)]
+    for m in (1,2,3,4,8,12,16,32,33):
+        x = torch.randn(m,weight.shape[1],device="cuda",dtype=torch.bfloat16)
+        bf = torch.nn.functional.linear(x,weight)
+        out = torch.ops.vllm.spark_mtp_fp8_head(x,weight,packed,scale)
+        ref = (x.float() @ packed.float().T * scale[None,:]).to(torch.bfloat16) if m <= 32 else bf
+        numerical = error(out,ref)
+        assert numerical["finite"] and numerical["relative_rmse"] < .006
+        slow = graph_ms(lambda w: torch.nn.functional.linear(x,w),weights)
+        fast = graph_ms(lambda ps: torch.ops.vllm.spark_mtp_fp8_head(x,weight,ps[0],ps[1]),fp8s)
+        print(json.dumps({"m":m,"passed":True,"kernel_error":numerical,
+            "vs_bf16_error":error(out,bf),"top1_matches":int((out.argmax(-1)==bf.argmax(-1)).sum()),
+            "top1_total":m,"bf16_ms":slow,"fp8_ms":fast,"speedup":slow/fast}),flush=True)
+    zeros = torch.zeros(32,2560,device="cuda",dtype=torch.bfloat16)
+    zp,zs = candidate.quantize_rows(zeros)
+    assert torch.isfinite(zs).all() and torch.count_nonzero(zp.float()) == 0
+    zeros[0,0] = float("nan")
+    try: candidate.quantize_rows(zeros)
+    except ValueError: pass
+    else: raise AssertionError("Nonfinite weights accepted")
+    module = torch.nn.Module()
+    module.lm_head = SimpleNamespace(tp_size=1)
+    module.register_buffer("_draft_lm_head_weight",weight,persistent=False)
+    candidate.attach_fp8_draft_head(module)
+    assert "_draft_lm_head_fp8" in dict(module.named_buffers())
+    assert "_draft_lm_head_fp8" not in module.state_dict()
+    assert torch.equal(original,module._draft_lm_head_weight)
+    print(json.dumps({"buffer_and_invalid_input_checks":True,"passed":True}),flush=True)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--snapshot",type=Path,required=True)
+    parser.add_argument("--draft-vocab",type=Path,required=True)
+    args = parser.parse_args()
+    main(args.snapshot,args.draft_vocab)

--- a/docs/sm121-code-benchmarks.md
+++ b/docs/sm121-code-benchmarks.md
@@ -1,0 +1,116 @@
+# GB10 opt-in kernel comparison: coding workloads
+
+Measured 2026-09-07 on one DGX Spark/GB10. Baseline is Mia's `ef1af5f`
+**with MTP3, reduced drafting, and BF16 recurrent state already enabled**;
+these are incremental gains, not comparisons against non-speculative decode.
+
+The submission branch is rebased onto `78b0675` (snapshot selection and the
+optional gated checkpoint). The measurements below remain from `ef1af5f` with
+the stock checkpoint; the newer launcher gets source checks/dry runs, not a
+fresh performance claim. The gated checkpoint was not benchmarked here.
+
+Two independent switches, both disabled by default:
+
+- `GDN_PREFILL_BACKEND=flashinfer`: explicit SM121 FlashInfer prefill path;
+  `auto` restores the existing resolver behavior.
+- `MTP_DRAFT_HEAD_FP8=1`: experimental W8A16 reduced draft head; `0` leaves
+  the original BF16 head in place. Target weights and sampling are unchanged.
+
+## Method
+
+Same image/checkpoint/vocabulary across four sequential fresh boots:
+
+- Image digest `sha256:fc120ece0a388cc0aa1caad4a9f1cd92113484ab7ec2fd0efadd62585be05bf8`;
+  vLLM `0.1.dev20073+g8e685d198`, PyTorch `2.13.0+cu130`, FlashInfer `0.6.17`.
+- `Mia-AiLab/Qwen3.8-Flash-Next-NVFP4` revision
+  `925d7be6c14c6c9442ef83e8f05b5a3c39304f69`.
+- TP1, native 262144 context, four sequences, 2048 prefill batch, 65536-ID
+  draft vocabulary, BF16 recurrent state, FP8 attention KV, V2 runner,
+  FULL_DECODE_ONLY graphs 4/8/12/16, compilation 0, GMU 0.737.
+- **32-GiB host reserve**, not the sample's 26 GiB. Speech daemons remained
+  resident but were not exercised; no MPS or compute cap. Local request timing
+  telemetry was present in every profile; it is not bundled in these patches.
+
+Four synthetic tasks: Python deep merge/diff, Python dependency planner,
+C++17 LRU, and C++17 lexical path normalization. Each ran three times at
+1/2/4 streams; all two-task pairings were covered. Six cold repository-repair
+prompts (three each at 6941/27120 tokens) plus two append-only follow-ups
+completed the suite. Six warmup requests per boot were excluded.
+
+200 total requests, 176 measured implementations. Temperature 0, fixed seed,
+thinking off, streaming usage, natural completion (1536-token safety ceiling).
+Short/cold prompt hashes matched across profiles. No foreign LLM traffic or
+preemption was detected. Every measured output ended naturally and parsed or
+compiled. Code was execution-tested only in non-root, no-network, read-only
+disposable containers with resource/time limits. Grader fixtures were frozen
+before measurement and self-tested with five positive/four negative controls.
+
+Decode below is the mean of the four per-task medians, using engine
+`(output_tokens - 1) / generation_time`, not the prefill-inclusive legacy rate.
+Prefill is median uncached tokens / scheduled-to-first-token time. All generated
+outputs, including functional failures, remain in these timing figures.
+
+## Comparison
+
+| Measurement | Baseline | GDN only | FP8 head only | Both |
+|---|---:|---:|---:|---:|
+| Solo code decode, tok/s | 53.81 | 53.56 | 56.60 | 56.76 |
+| 2-stream code decode, tok/s per request | 44.27 | 44.09 | 46.05 | 45.85 |
+| 4-stream code decode, tok/s per request | 35.49 | 35.27 | 35.74 | 35.96 |
+| Cold 6941-token code prefill, tok/s | 1959 | 2093 | 1980 | 2088 |
+| Cold 27120-token code prefill, tok/s | 2027 | 2155 | 2044 | 2140 |
+| 27120-token client TTFT, seconds | 13.43 | 12.65 | 13.33 | 12.73 |
+| 4-stream batch end-to-end aggregate, tok/s | 115.15 | 114.68 | 109.68 | 115.32 |
+| Whole implementations passing fixed tests | 42/44 | 41/44 | 39/44 | 40/44 |
+
+Combined: **+5.5% solo decode, +3.6% at two streams, +1.3% at four;
+and +5.5–6.6% cold prefill.** GDN alone delivers 6.3–6.8% faster prefill with
+essentially unchanged decode. FP8 alone gives 5.2% solo code decode gain;
+estimated solo decode-step time falls from 60.13 to 57.57 ms, with similar
+acceptance (0.761→0.769). Combined step time is 58.20 ms, acceptance 0.763.
+
+## What the numbers do not establish
+
+- **Four-stream batch throughput is effectively flat.** Natural completions
+  have different lengths, so batches drain toward lower concurrency. Do not
+  multiply per-request decode by stream count to infer aggregate throughput.
+- Faster tokens did not consistently shorten completed-task latency. Solo
+  task-balanced elapsed time was 9.19 s baseline versus 9.56 s combined;
+  longer generated implementations can spend the token-rate improvement.
+- The main four-task correctness subset scored 35/36, 35/36, 34/36, 35/36.
+  Both FP8 profiles generated one path normalizer that incorrectly reduced
+  `../..` to `.`; baseline/GDN instead each had one incorrect planner.
+  Repository repairs scored 7/8, 6/8, 5/8, 5/8. Those failures interpreted
+  "touching integer intervals" as adjacency (`start <= end + 1`), while the
+  frozen grader required shared endpoints (`start <= end`). We did not change
+  the scorer. A repeated warm answer is correlated with its preceding answer.
+- Even baseline's identical greedy solo requests produced different source
+  texts. This small suite neither establishes kernel-caused quality degradation
+  nor demonstrates quality equivalence. **FP8 remains experimental.**
+- Restricting decode to passing outputs yields 53.74/44.27/35.49 tok/s baseline
+  versus 56.76/45.85/35.92 combined. That filtering is survivor-biased; it is
+  not a substitute for reporting all failures.
+- One boot per profile and three repeats are directional evidence, not tight
+  confidence intervals, SWE-bench, or a full coding-agent evaluation.
+
+## Memory and compatibility
+
+The FP8 copy/scales cost **0.1565 GiB** beyond retained BF16 buffers. Actual
+profiled KV was baseline 697098 tokens/10.45 GiB, GDN 675130/10.12,
+FP8 648769/9.72, combined 675130/10.11. Combined capacity was 3.2% lower
+than this baseline, but boot/workspace variation is larger than the known
+buffer alone. Host reserve was not reduced. Minimum combined MemAvailable
+was 14.48 GiB; no watchdog stop, unexpected restart, or OOM kill occurred.
+Recovered startup NVIDIA allocation warnings numbered 2/0/1/1; none occurred
+during measured serving. This is not an endurance or maximum-capacity test.
+
+All profiles reused 4992/~7K and 24960/~27K prefix tokens on append-only
+follow-ups. Final combined Unicode/tool checks passed 3/3, and Chat/Responses
+cache/timing checks, including final streaming metrics, passed 6/6.
+
+For source guards, isolated numerical tests, per-feature reproduction, and
+the earlier prose A/B, see [GDN](sm121-gdn-prefill.md) and
+[FP8 draft head](sm121-mtp-fp8-head.md). Credit to
+[Gabriel Olympie (@gabrielolympie)](https://github.com/gabrielolympie/sglang-flashnext-sm120/tree/67d2f9234fa45ae1339f0d53cd37cb695e9c6493)
+for the original SM120 work; [attribution and licensing](../THIRD_PARTY_NOTICES.md)
+describe the GB10/vLLM adaptation.

--- a/docs/sm121-gdn-prefill.md
+++ b/docs/sm121-gdn-prefill.md
@@ -1,0 +1,132 @@
+# Opt-in FlashInfer GDN prefill on GB10
+
+This is a small backend-selection patch, not an SGLang port. FlashInfer 0.6.17
+already ships a native SM12x GDN kernel and selects `sm_121a` on GB10. The
+installed vLLM resolver excludes SM121. The overlay permits that path only for
+an explicit `GDN_PREFILL_BACKEND=flashinfer`, CUDA 13+, and 128-wide key/value heads.
+`auto` preserves the existing Triton/FLA choice. Decode selection is unchanged.
+
+The idea was investigated after reviewing
+[Gabriel Olympie's (@gabrielolympie) SM120 patches](https://github.com/gabrielolympie/sglang-flashnext-sm120/tree/67d2f9234fa45ae1339f0d53cd37cb695e9c6493),
+especially their FP32 prefill-state handling. vLLM's existing FlashInfer adapter
+already converts initial state/gates to FP32, and FlashInfer converts sequence
+offsets to int64. Neither of those adapters needs replacing here.
+
+## Reproduction and scope
+
+Measured 2026-09-06 on one DGX Spark/GB10, recipe base `ef1af5f`, with local
+request telemetry and a 32 GiB host reserve. Same image, checkpoint, context,
+memory reserve, and scheduling limits on both sides:
+
+- Image `vllm/vllm-openai:qwen38-flash-next`, digest
+  `sha256:fc120ece0a388cc0aa1caad4a9f1cd92113484ab7ec2fd0efadd62585be05bf8`.
+- vLLM `0.1.dev20073+g8e685d198`, PyTorch `2.13.0+cu130`, FlashInfer `0.6.17`.
+- `Mia-AiLab/Qwen3.8-Flash-Next-NVFP4` revision
+  `925d7be6c14c6c9442ef83e8f05b5a3c39304f69`.
+- TP1, native 262144 context, 4 sequences, prefill batch 2048, FP8 attention KV,
+  BF16 recurrent state, V2 runner, MTP3, same 65536-entry draft vocabulary.
+- FULL_DECODE_ONLY graphs 4/8/12/16, compilation mode 0, GMU 0.737.
+- Speech containers remained running but were not benchmarked; no MPS/caps.
+
+Serving results are medians of three repetitions, after two excluded 32K
+warmups. Decode requests generate 600 tokens each. Cold prompts have unique
+early salts and reported zero cached tokens. Every request completed and
+counter deltas matched the benchmark's request counts (no other LLM traffic).
+
+| Measurement | Triton/FLA | FlashInfer |
+|---|---:|---:|
+| Cold ~8K prefill, tok/s | 2096.6 | 2225.9 (+6.2%) |
+| Cold ~32K prefill, tok/s | 2084.1 | 2226.3 (+6.8%) |
+| ~8K client TTFT | 3.867 s | 3.639 s |
+| ~32K client TTFT | 15.454 s | 14.457 s |
+| Solo decode, tok/s | 34.95 | 34.90 |
+| 2-stream decode, tok/s per stream | 29.91 | 31.33 |
+| 4-stream decode, tok/s per stream | 23.62 | 23.51 |
+
+Do **not** interpret the 2-stream throughput increase as a decode-kernel win:
+draft acceptance varied. Estimated decode-step medians were 60.90→61.03 ms
+(solo), 72.75→72.48 ms (2 streams), and 91.56→92.01 ms (4 streams).
+That is effectively unchanged at this sample size. Different floating-point
+prefill implementations can produce different subsequent token trajectories.
+
+The first measured ~8K FlashInfer request took 4.33 s, whereas the subsequent
+ones took 3.60–3.64 s. The reported median includes it. Startup/JIT and first-use
+effects are not a steady-state speed guarantee.
+
+### Coding follow-up (2026-09-07)
+
+Same image and inference controls, with four synthetic Python/C++ tasks at
+1/2/4 streams (three repetitions each), plus cold repository-repair prompts.
+Thinking off, temperature 0, natural completion; 50 requests per profile,
+including six excluded warmups. Short-task decode is the mean of four per-task
+medians, not aggregate throughput.
+
+| Measurement | Triton/FLA | FlashInfer |
+|---|---:|---:|
+| Cold 6941-token code prefill, tok/s | 1959 | 2093 (+6.8%) |
+| Cold 27120-token code prefill, tok/s | 2027 | 2155 (+6.3%) |
+| Solo code decode, tok/s | 53.81 | 53.56 |
+| 2-stream code decode, tok/s per request | 44.27 | 44.09 |
+| 4-stream code decode, tok/s per request | 35.49 | 35.27 |
+| Whole implementations passing fixed tests | 42/44 | 41/44 |
+
+Both profiles passed 35/36 on the four short tasks, each with one incorrect
+planner. Repository repairs passed 7/8 versus 6/8; those failures interpreted
+"touching integer intervals" differently from the frozen grader. No prompt or
+test was changed after seeing results. Even the baseline's repeated greedy
+requests generated different source texts, so this is not a proof of bitwise
+or model-quality equivalence. All outputs compiled/parsed and ended naturally;
+no preemptions or unrelated LLM traffic were detected. KV profiling this time
+was 697098→675130 tokens (10.45→10.12 GiB), illustrating boot variation.
+
+## Correctness and costs
+
+- Five CPU tests cover opt-in/default behavior, unsupported GPU/geometry/CUDA,
+  unavailable kernels, source drift, and double application.
+- Thirteen isolated GPU checks compare outputs **and final state** against
+  FLA with actual 16-key/48-value-head geometry, ragged batches, short tails,
+  ordinary/slow decay, and resumed 1664-token BF16-state chunks. All finite;
+  maximum relative RMS differences about 0.57% (output) and 0.48% (state).
+  These are numerical comparisons, not bitwise equality.
+- At 2048 tokens, the isolated adapter measured 2.214→0.551 ms (~4×). Only a
+  fraction of end-to-end prefill uses this kernel; the serving gain is ~7%.
+- Six 32K/128K retrieval and append-only continuation requests passed, including
+  reuse of 29952 and 124800 cached tokens. No broken recurrence/cache behavior
+  was observed in this bounded test.
+- The same four answer-level mistakes occurred in the 18-question greedy/
+  temperature-0.7 synthetic suite: **14/18 correct both before and after**.
+  Exact-format scores were 10/18 and 11/18. This is not a general accuracy or
+  long-reasoning evaluation, and is not evidence of improved intelligence.
+- Unicode and auto/forced tool checks passed; all six Chat/Responses timing/
+  cache canaries passed, including final streaming usage metrics.
+- A separately retained prose sample was coherent. Generated Python interval-
+  merging code passed 100 edge/randomized cases without mutating its inputs,
+  executed only in an unprivileged, no-network, read-only disposable container.
+- KV boot capacity was **726387→705884 tokens** (10.88→10.57 GiB), about 2.8%
+  lower under the same host safety budget. Treat this as an observed profiling/
+  workspace cost, not a universal constant. Do not lower the reserve to hide it.
+- No unexpected container restarts or engine failures during these tests.
+  The kernel journal did record five recovered `NV_ERR_NO_MEMORY` allocation
+  warnings during loading, before readiness; none during serving. The prior
+  baseline boot also had recovered driver allocation warnings. Existing
+  Transformers video-processor documentation warnings remain. This test does
+  not establish that the broader deployment's startup memory behavior is fixed.
+
+The patch validates the entire input source hash before writing the overlay.
+An image/source update fails closed and needs review. No checkpoint or disk KV
+cache is modified. Set `GDN_PREFILL_BACKEND=auto` and restart to return to stock.
+
+## Tests
+
+CPU resolver tests run in the image, without GPU or network:
+
+```sh
+docker run --rm --network none --memory 512m \
+  -e PYTHONDONTWRITEBYTECODE=1 -v "$PWD/files:/tests:ro" -w /tests \
+  --entrypoint python3 vllm/vllm-openai:qwen38-flash-next test_gdn_sm121.py
+```
+
+`bench/gdn_sm121_preflight.py` runs the isolated numerical/state comparisons.
+Run it in the serving image with GPU access **while the LLM is stopped**, in a
+bounded disposable container. It does not load the checkpoint or change the
+serving process. First compilation took about 37 seconds in this test.

--- a/docs/sm121-mtp-fp8-head.md
+++ b/docs/sm121-mtp-fp8-head.md
@@ -1,0 +1,134 @@
+# Opt-in FP8 reduced MTP draft head on GB10
+
+**Experimental; disabled by default.** The
+[coding follow-up](sm121-code-benchmarks.md) measured about 5% faster solo
+code token production, but no four-stream batch-throughput gain or demonstrated
+quality equivalence. Read its execution-test failures before enabling this.
+
+`MTP_DRAFT_HEAD_FP8=1` adds a row-scaled E4M3 copy of the existing reduced
+BF16 draft head. The Triton kernel reads FP8 weights, dequantizes tiles to
+BF16, accumulates in FP32, applies FP32 row scales, and returns BF16 logits.
+This is W8A16 weight-only drafting, not FP8 activation quantization.
+
+It changes only MTP `get_top_tokens`; the target model's head, target weights,
+full-vocabulary verification, tokenizer mapping, forward pass, and rejection
+sampling are untouched. Original BF16 draft buffers are retained. This does
+not promise bit-identical generated strings: numerical batching and speculative
+paths can change trajectories even when the target weights are identical.
+
+The kernel is adapted from Apache-2.0 kernels in
+[Gabriel Olympie's (@gabrielolympie) patches 0004/0005](https://github.com/gabrielolympie/sglang-flashnext-sm120/tree/67d2f9234fa45ae1339f0d53cd37cb695e9c6493).
+Attribution and the retained kernel license are in
+[THIRD_PARTY_NOTICES.md](../THIRD_PARTY_NOTICES.md).
+The GB10 tactic (N tile 32, K tile 256, 3 stages, no split-K) was selected using
+serialized CUDA graph timing with cold weight rings larger than L2. None of
+the SGLang runtime, target-weight quantization, or relaxed acceptance is ported.
+
+## Enable and disable
+
+Keep the same MTP depth and draft vocabulary when comparing:
+
+```sh
+# Stop the running LLM safely first; do not start a second copy.
+MTP_DRAFT_HEAD_FP8=1 ./start.sh
+```
+
+Requires a valid `MTP_DRAFT_VOCAB`, MTP enabled, TP1, SM121, and a BF16 Qwen
+head with hidden width 2560. Unsupported geometry fails clearly. Set the knob
+to 0 and restart to remove the override entirely. The default is 0.
+
+Mia's reduced-vocabulary patch runs first. A separate source-exact patch then
+checks its hash before generating the optional MTP overlay. On an incompatible
+image or recipe update it fails closed. No checkpoint file is modified, no
+FP8 weight copy is written to disk, and this is not a durable KV cache.
+
+FP8 buffers are module-owned, nonpersistent, and prepared after loading but
+before graph capture. There is no global data-pointer cache, eviction policy,
+or capture-time quantization. Large batches (>32 rows) use the original BF16
+head. Small-batch fallback is also retained for unsupported activation layouts.
+
+## Isolated and serving results
+
+Measured 2026-09-06 on one GB10; recipe base `ef1af5f` plus local telemetry
+and host safety overlays. The FlashInfer GDN candidate was **disabled** for
+this measurement. Both sides used:
+
+- `vllm/vllm-openai:qwen38-flash-next`, digest
+  `sha256:fc120ece0a388cc0aa1caad4a9f1cd92113484ab7ec2fd0efadd62585be05bf8`.
+- vLLM `0.1.dev20073+g8e685d198`, PyTorch `2.13.0+cu130`.
+- `Mia-AiLab/Qwen3.8-Flash-Next-NVFP4` revision
+  `925d7be6c14c6c9442ef83e8f05b5a3c39304f69`.
+- Native 262144 context, TP1, 4 sequences, 2048 prefill chunk, FP8 attention
+  KV, BF16 recurrent state, MTP3, identical 65536-token draft vocabulary.
+- FULL_DECODE_ONLY graphs 4/8/12/16, compilation 0, V2 runner, GMU 0.737,
+  32 GiB host reserve. No MPS or compute caps. Speech daemons were unchanged;
+  no speech benchmark workload was generated.
+
+Serving numbers are medians of three repetitions, 600 output tokens per
+request, after two excluded 32K warmups. Request counters matched the test
+traffic throughout. These are workload-specific measurements, not guarantees.
+
+| Measurement | BF16 reduced head | FP8 reduced head |
+|---|---:|---:|
+| Solo prose decode, tok/s | 34.95 | 36.26 (+3.8%) |
+| 2 streams, tok/s per stream | 29.91 | 30.73 (+2.8%) |
+| 4 streams, tok/s per stream | 23.62 | 24.12 (+2.1%) |
+| Estimated solo decode step | 60.90 ms | 58.37 ms |
+| Estimated 2-stream decode step | 72.75 ms | 70.24 ms |
+| Estimated 4-stream decode step | 91.56 ms | 89.49 ms |
+
+Solo acceptance fraction was 0.385→0.373; some of the kernel gain was spent
+on rejected proposals. The 2-/4-stream fractions were 0.391→0.395 and
+0.388→0.387. The reduction in step cost is more consistent than raw tok/s,
+which also follows the particular generated text and acceptance.
+
+Using the **actual checkpoint head** with synthetic hidden activations:
+
+| M | BF16 kernel | FP8 kernel |
+|---|---:|---:|
+| 1 | 1.909 ms | 0.699 ms (2.73×) |
+| 4 | 1.426 ms | 0.706 ms (2.02×) |
+| 16 | 1.454 ms | 0.716 ms (2.03×) |
+
+The whole model is not 2–3× faster; the head is only part of each step.
+Cold ~8K/~32K prefill measured 2125/2119 tok/s versus 2097/2084 before, a
+small difference that should not be advertised as a prefill-kernel improvement.
+
+## Correctness and memory
+
+- Nine actual-head batch sizes (1,2,3,4,8,12,16,32,33) passed numerical
+  checks. Kernel vs FP32 reference on the quantized weights had relative RMS
+  error below 0.007%. FP8 approximation vs original BF16 was ~2.6–2.7% RMS.
+  Batch 33 took an exact BF16 fallback. Synthetic top-1 agreement is not a
+  substitute for actual serving acceptance or a model-quality evaluation.
+- Zero rows stayed finite; nonfinite weights were rejected. Original BF16
+  weights were bitwise unchanged. Extra buffers were excluded from state_dict.
+- Four CPU tests verify source drift, scope, opt-in, and nonpersistent storage.
+- 32K/128K retrieval plus append-only cache continuation passed all six cases.
+  Unicode and both automatic/forced tool calls passed.
+- All six Chat/Responses cache/timing canaries passed, including streaming.
+- Natural prose was coherent. A generated interval-merging Python function
+  passed 100 edge/random cases and input-nonmutation checks in a separate,
+  network-disabled, read-only, resource-limited container.
+- Synthetic answer-level score was 15/18 versus 14/18 in the baseline, with
+  thinking off at temperatures 0 and 0.7. Exact-format score was 11/18 versus
+  10/18. These small scores do **not** demonstrate increased intelligence or
+  establish absence of regressions on arbitrary reasoning/multimodal tasks.
+- The 65536-row FP8 copy and scales cost **0.1565 GiB** beyond the retained
+  BF16 buffers. Known memory cost scales with draft-vocabulary size.
+- Boot KV was 688311 tokens / 10.31 GiB versus baseline 726387 / 10.88 GiB.
+  That observed pool change is larger than the buffers alone; profiling and
+  workspace allocation vary across boots. Do not attribute all of it to FP8
+  storage or compensate by reducing the host reserve.
+- No unexpected engine restart, serving-time driver allocation failure, or
+  OOM kill occurred during the measured serving workload. This does not fix
+  the deployment's preexisting startup allocation-warning behavior.
+- The recipe-style `VLLM_MTP_DRAFT_HEAD_FP8` environment flag produces an
+  unknown-vLLM-variable warning, like the existing draft-vocabulary flag. The
+  model helper reads it explicitly; its startup log confirms activation.
+
+`bench/mtp_fp8_head_preflight.py` is a self-contained actual-head check. Run it
+in a bounded GPU container while the LLM is stopped, with
+`VLLM_MTP_DRAFT_HEAD_FP8=1`, the helper importable from `files/`, and explicit
+`--snapshot` / `--draft-vocab` paths. Mount model files read-only and disable
+network access. It does not start an API server or alter weights on disk.

--- a/files/patch_gdn_sm121.py
+++ b/files/patch_gdn_sm121.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in FlashInfer GDN prefill on GB10; no automatic backend change.
+
+Applied to an exact image source in a disposable CPU container. The installed
+FlashInfer must provide its SM12x CuTe DSL kernel. Numeric/state and serving
+tests are recorded separately; this patch never changes the decode backend.
+"""
+import argparse
+import ast
+import hashlib
+import json
+from pathlib import Path
+
+SOURCE = Path("/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py")
+EXPECTED_SHA256 = "81b4dcd0952492375c93bffc2cdf45f10b45ab5e117f2e1d949a147d144e64f0"
+ANCHOR = '''        supports_flashinfer = True
+        supports_cutedsl = True
+
+    if backend in ["flashinfer", "auto"] and supports_flashinfer:
+'''
+REPLACEMENT = '''        supports_flashinfer = True
+        supports_cutedsl = True
+    elif (
+        backend == "flashinfer"
+        and current_platform.is_device_capability((12, 1))
+        and head_k_dim == 128
+        and getattr(vllm_config.model_config.hf_text_config, "linear_value_head_dim", None) == 128
+        and current_platform.get_cuda_runtime_major() >= 13
+    ):
+        # GB10 is deliberately opt-in. FlashInfer 0.6.17 includes a native
+        # SM12x path; the existing adapter supplies FP32 state/gates and the
+        # FlashInfer wrapper converts cu_seqlens to int64. Do not enable the
+        # separate SM10x-only in-tree CuteDSL backend here.
+        from flashinfer.gdn_kernels import chunk_gated_delta_rule_sm120
+
+        if chunk_gated_delta_rule_sm120 is None:
+            raise RuntimeError("FlashInfer SM12x GDN prefill kernel is unavailable")
+        supports_flashinfer = True
+
+    if backend in ["flashinfer", "auto"] and supports_flashinfer:
+'''
+
+
+def patch(source):
+    digest = hashlib.sha256(source.encode()).hexdigest()
+    if digest != EXPECTED_SHA256 or source.count(ANCHOR) != 1:
+        raise RuntimeError(f"GDN source drift ({digest}); refusing unvalidated patch")
+    result = source.replace(ANCHOR, REPLACEMENT)
+    ast.parse(result)
+    return result
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", type=Path, default=SOURCE)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    args.output.write_text(patch(args.source.read_text()))
+    print(json.dumps({"patch": "gdn_sm121", "source_sha256": EXPECTED_SHA256,
+                      "output_sha256": hashlib.sha256(args.output.read_bytes()).hexdigest()}))

--- a/files/patch_mtp_fp8_head.py
+++ b/files/patch_mtp_fp8_head.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Source-exact optional overlay AFTER Mia's reduced-vocabulary MTP patch."""
+import argparse
+import ast
+import hashlib
+import json
+from pathlib import Path
+
+EXPECTED_SHA256 = "8da66d9f48bd93c935d74e2635c45483dc999c87b94bc4ce828e727eb1713349"
+EDITS = (
+    ("from .low_latency_gemm import enable_qwen38next_low_latency_gemm\n",
+     "from .low_latency_gemm import enable_qwen38next_low_latency_gemm\n"
+     "from .spark_mtp_fp8_head import attach_fp8_draft_head\n"),
+    ("        _attach_draft_vocab(self)\n        return loaded\n",
+     "        _attach_draft_vocab(self)\n        attach_fp8_draft_head(self)\n        return loaded\n"),
+    ("        logits = torch.nn.functional.linear(hidden_states.to(weight.dtype), weight)\n",
+     "        fp8 = getattr(self, \"_draft_lm_head_fp8\", None)\n"
+     "        if fp8 is None:\n"
+     "            logits = torch.nn.functional.linear(hidden_states.to(weight.dtype), weight)\n"
+     "        else:\n"
+     "            logits = torch.ops.vllm.spark_mtp_fp8_head(\n"
+     "                hidden_states, weight, fp8, self._draft_lm_head_fp8_scale\n"
+     "            )\n"),
+)
+
+
+def patch(source):
+    digest = hashlib.sha256(source.encode()).hexdigest()
+    if digest != EXPECTED_SHA256:
+        raise RuntimeError(f"Reduced MTP source drift ({digest}); refusing unvalidated patch")
+    for old, new in EDITS:
+        if source.count(old) != 1:
+            raise RuntimeError("Expected exactly one MTP source anchor")
+        source = source.replace(old, new)
+    ast.parse(source)
+    return source
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    result = patch(args.source.read_text())
+    args.output.write_text(result)
+    print(json.dumps({"patch": "mtp_fp8_head", "source_sha256": EXPECTED_SHA256,
+                      "output_sha256": hashlib.sha256(result.encode()).hexdigest()}))

--- a/files/spark_mtp_fp8_head.py
+++ b/files/spark_mtp_fp8_head.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in GB10 W8A16 reduced MTP head; target logits remain untouched.
+
+Kernel adapted by Raymond Lucke from Gabriel Olympie's (@gabrielolympie)
+sglang-flashnext-sm120, patches 0004/0005,
+commit 67d2f9234fa45ae1339f0d53cd37cb695e9c6493 (Apache-2.0 kernels).
+See LICENSES/Apache-2.0.txt and THIRD_PARTY_NOTICES.md in this recipe.
+The (N=32, K=256, stages=3) tactic was measured on SM121 with cold weights
+under serialized CUDA graph replay, not copied from RTX timings.
+
+Original BF16 buffers are retained. FP8/scales are nonpersistent module-owned
+buffers created after loading, never a data_ptr-keyed global cache or a lazy
+capture-time quantization. No target-model, tokenizer, or sampler patch.
+"""
+import os
+
+import torch
+import triton
+import triton.language as tl
+
+from vllm.logger import init_logger
+from vllm.utils.torch_utils import direct_register_custom_op
+
+logger = init_logger(__name__)
+
+
+@triton.jit
+def _head(X, W, S, O, M: tl.constexpr, N: tl.constexpr, K: tl.constexpr,
+          XM: tl.constexpr, BM: tl.constexpr):
+    rn = tl.program_id(0)*32 + tl.arange(0, 32)
+    rm = tl.arange(0, BM)
+    acc = tl.zeros((BM, 32), tl.float32)
+    for k0 in tl.range(0, K, 256, num_stages=3):
+        rk = k0 + tl.arange(0, 256)
+        x = tl.load(X + rm[:, None]*XM + rk[None, :],
+                    (rm[:, None] < M) & (rk[None, :] < K), other=0.0)
+        w = tl.load(W + rn[:, None]*K + rk[None, :],
+                    (rn[:, None] < N) & (rk[None, :] < K), other=0.0).to(tl.bfloat16)
+        acc += tl.dot(x, tl.trans(w), out_dtype=tl.float32)
+    scale = tl.load(S + rn, rn < N, other=0.0)
+    acc = acc * scale[None, :]
+    tl.store(O + rm[:, None]*N + rn[None, :], acc,
+             (rm[:, None] < M) & (rn[None, :] < N))
+
+
+def _logits(x: torch.Tensor, bf16: torch.Tensor, fp8: torch.Tensor,
+            scale: torch.Tensor) -> torch.Tensor:
+    if (x.ndim != 2 or x.dtype != torch.bfloat16 or not x.is_cuda
+            or not 0 < x.shape[0] <= 32 or x.stride(1) != 1):
+        return torch.nn.functional.linear(x.to(bf16.dtype), bf16)
+    m, k = x.shape
+    n = fp8.shape[0]
+    out = x.new_empty((m, n))
+    _head[(triton.cdiv(n, 32),)](x, fp8, scale, out, m, n, k, x.stride(0),
+                               max(16, triton.next_power_of_2(m)), num_warps=4)
+    return out
+
+
+def _fake(x: torch.Tensor, bf16: torch.Tensor, fp8: torch.Tensor,
+          scale: torch.Tensor) -> torch.Tensor:
+    return x.new_empty((*x.shape[:-1], bf16.shape[0]), dtype=bf16.dtype)
+
+
+direct_register_custom_op(op_name="spark_mtp_fp8_head", op_func=_logits, fake_impl=_fake)
+
+
+@torch.no_grad()
+def quantize_rows(weight: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-output-row E4M3 weights, FP32 scales; <=32 MiB FP32 chunk."""
+    if weight.ndim != 2 or weight.dtype != torch.bfloat16 or not weight.is_contiguous():
+        raise ValueError("FP8 draft head requires a contiguous 2D BF16 head")
+    packed = torch.empty_like(weight, dtype=torch.float8_e4m3fn)
+    scale = torch.empty(weight.shape[0], dtype=torch.float32, device=weight.device)
+    rows = max(1, (32*1024*1024)//(weight.shape[1]*4))
+    for start in range(0, weight.shape[0], rows):
+        chunk = weight[start:start+rows].float()
+        if not torch.isfinite(chunk).all():
+            raise ValueError("Non-finite BF16 draft-head weights")
+        s = (chunk.abs().amax(dim=1)/448).clamp_min(1e-12)
+        packed[start:start+rows] = (chunk/s[:, None]).clamp(-448, 448).to(packed.dtype)
+        scale[start:start+rows] = s
+    return packed, scale
+
+
+@torch.no_grad()
+def attach_fp8_draft_head(model: torch.nn.Module) -> None:
+    if os.environ.get("VLLM_MTP_DRAFT_HEAD_FP8", "0") != "1":
+        return
+    weight = getattr(model, "_draft_lm_head_weight", None)
+    if (weight is None or not weight.is_cuda or weight.shape[1] != 2560
+            or torch.cuda.get_device_capability(weight.device) != (12, 1)
+            or getattr(model.lm_head, "tp_size", 1) != 1):
+        raise RuntimeError("MTP_DRAFT_HEAD_FP8 requires SM121, TP1, and a loaded reduced Qwen head")
+    if torch.cuda.is_current_stream_capturing():
+        raise RuntimeError("FP8 draft head must be prepared before graph capture")
+    packed, scales = quantize_rows(weight)
+    model.register_buffer("_draft_lm_head_fp8", packed, persistent=False)
+    model.register_buffer("_draft_lm_head_fp8_scale", scales, persistent=False)
+    # The real graph warmup covers all actual M values. Explicitly compile
+    # the basic tactic here so no lazy quantization/JIT is hidden in capture.
+    for m in (1, 2, 4, 8, 12, 16):
+        _logits(torch.zeros((m, weight.shape[1]), dtype=weight.dtype, device=weight.device),
+                weight, packed, scales)
+    logger.info("MTP FP8 draft head: %d rows; %.3f GiB extra immutable buffers; "
+                "target weights and rejection sampling unchanged",
+                weight.shape[0], (packed.numel()+scales.numel()*4)/2**30)

--- a/files/test_gdn_sm121.py
+++ b/files/test_gdn_sm121.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU contract tests. Run in the serving image; no GPU or downloads needed.
+
+GDN_TEST_SOURCE may override the installed-image source for local testing.
+"""
+import ast
+import os
+from pathlib import Path
+from types import SimpleNamespace
+import unittest
+from unittest.mock import patch as mock_patch
+
+import patch_gdn_sm121 as patcher
+
+
+class Platform:
+    def __init__(self, cap): self.cap = cap
+    def is_cuda(self): return self.cap is not None
+    def is_device_capability(self, want):
+        actual = self.cap[0]*10+self.cap[1] if self.cap else -1
+        return actual == (want[0]*10+want[1] if isinstance(want, tuple) else want)
+    def is_device_capability_family(self, want): return bool(self.cap and self.cap[0] == want//10)
+    def get_cuda_runtime_major(self): return 13
+
+
+class Tests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.source = Path(os.environ.get("GDN_TEST_SOURCE", str(patcher.SOURCE))).read_text()
+
+    def resolve(self, cap, backend="auto", head_dim=128, value_dim=128, cuda=13, available=True):
+        tree = ast.parse(patcher.patch(self.source))
+        fn = next(n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "_resolve_gdn_prefill_backend")
+        fn.returns = None
+        fn.args.args[0].annotation = None
+        platform = Platform(cap)
+        platform.get_cuda_runtime_major = lambda: cuda
+        ns = {"current_platform": platform}
+        exec(compile(ast.Module(body=[fn], type_ignores=[]), "resolver", "exec"), ns)
+        config = SimpleNamespace(additional_config={"gdn_prefill_backend": backend},
+            model_config=SimpleNamespace(hf_text_config=SimpleNamespace(
+                linear_key_head_dim=head_dim, linear_value_head_dim=value_dim)))
+        kernels = SimpleNamespace(chunk_gated_delta_rule_sm120=(lambda: None) if available else None)
+        with mock_patch.dict("sys.modules", {"flashinfer.gdn_kernels": kernels}):
+            return ns["_resolve_gdn_prefill_backend"](config)[1]
+
+    def test_opt_in(self):
+        self.assertEqual(self.resolve((12,1)), "triton")
+        self.assertEqual(self.resolve((12,1), "flashinfer"), "flashinfer")
+        self.assertEqual(self.resolve((12,1), "cutedsl"), "triton")
+    def test_other_platforms(self):
+        self.assertEqual(self.resolve(None, "flashinfer"), "triton")
+        self.assertEqual(self.resolve((12,0), "flashinfer"), "triton")
+        self.assertEqual(self.resolve((9,0)), "flashinfer")
+        self.assertEqual(self.resolve((10,3)), "flashinfer")
+    def test_geometry_and_cuda(self):
+        self.assertEqual(self.resolve((12,1), "flashinfer", head_dim=64), "triton")
+        self.assertEqual(self.resolve((12,1), "flashinfer", value_dim=256), "triton")
+        self.assertEqual(self.resolve((12,1), "flashinfer", cuda=12), "triton")
+    def test_missing_kernel(self):
+        with self.assertRaises(RuntimeError):
+            self.resolve((12,1), "flashinfer", available=False)
+    def test_source_drift(self):
+        for bad in (self.source + "\n", patcher.patch(self.source)):
+            with self.assertRaises(RuntimeError): patcher.patch(bad)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/files/test_mtp_fp8_head.py
+++ b/files/test_mtp_fp8_head.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU source-scope checks, against Mia's generated reduced-vocabulary MTP.
+
+Run after start.sh --no-launch (which generates files/mtp_patched.py), or set
+MTP_TEST_SOURCE to the validated source. Does not load the model or GPU.
+"""
+import ast
+import os
+from pathlib import Path
+import unittest
+
+import patch_mtp_fp8_head as patcher
+
+
+class Tests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.source = Path(os.environ.get("MTP_TEST_SOURCE",
+                          str(Path(__file__).with_name("mtp_patched.py")))).read_text()
+
+    def test_only_draft_selection_and_load_change(self):
+        def bodies(source):
+            tree = ast.parse(source)
+            cls = next(n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "Qwen3_8FlashNextMTP")
+            return {n.name: ast.dump(n) for n in cls.body if isinstance(n, ast.FunctionDef)}
+        before, after = bodies(self.source), bodies(patcher.patch(self.source))
+        self.assertEqual({k for k in before if before[k] != after[k]}, {"get_top_tokens", "load_weights"})
+        for unchanged in ("compute_logits", "forward", "__init__", "embed_input_ids"):
+            self.assertEqual(before[unchanged], after[unchanged])
+
+    def test_other_top_level_functions_unchanged(self):
+        def functions(source):
+            return {n.name: ast.dump(n) for n in ast.parse(source).body if isinstance(n, ast.FunctionDef)}
+        self.assertEqual(functions(self.source), functions(patcher.patch(self.source)))
+
+    def test_source_drift(self):
+        for bad in (self.source + "\n", patcher.patch(self.source)):
+            with self.assertRaises(RuntimeError): patcher.patch(bad)
+
+    def test_runtime_has_explicit_opt_in_and_nonpersistent_buffers(self):
+        source = Path(__file__).with_name("spark_mtp_fp8_head.py").read_text()
+        tree = ast.parse(source)
+        attach = next(n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "attach_fp8_draft_head")
+        self.assertIsInstance(attach.body[0], ast.If)
+        self.assertIn("VLLM_MTP_DRAFT_HEAD_FP8", ast.unparse(attach.body[0].test))
+        self.assertIsInstance(attach.body[0].body[0], ast.Return)
+        registrations = [n for n in ast.walk(attach) if isinstance(n, ast.Call)
+                         and isinstance(n.func, ast.Attribute) and n.func.attr == "register_buffer"]
+        self.assertEqual(len(registrations), 2)
+        for call in registrations:
+            self.assertTrue(any(k.arg == "persistent" and isinstance(k.value, ast.Constant)
+                                and k.value.value is False for k in call.keywords))
+
+
+if __name__ == "__main__": unittest.main()

--- a/start.sh
+++ b/start.sh
@@ -112,7 +112,7 @@ _ENV_SNAPSHOT_VARS=(KV_TARGET_GIB HOST_RESERVE_GIB HOST_SLACK_GIB OS_RESERVE_GIB
                     MAMBA_SSM_CACHE_DTYPE GDN_PREFILL_BACKEND
                     IMAGE SERVED_MODEL_NAME CUDAGRAPH_MODE HF_TOKEN
                     CUDAGRAPH_CAPTURE_SIZES COMPILATION_MODE MTP_K_SCHEDULE
-                    MTP_DRAFT_VOCAB
+                    MTP_DRAFT_VOCAB MTP_DRAFT_HEAD_FP8
                     EXTRA_VLLM_ARGS EXTRA_DOCKER_ARGS NATIVE_MAX_MODEL_LEN
                     YARN_CEILING_MODEL_LEN)
 for _v in "${_ENV_SNAPSHOT_VARS[@]}"; do
@@ -245,6 +245,15 @@ MTP_K_SCHEDULE="${MTP_K_SCHEDULE:-}"
 # trades acceptance for bandwidth and cannot change what the server emits.
 # Empty disables it and the drafter keeps the full head.
 MTP_DRAFT_VOCAB="${MTP_DRAFT_VOCAB:-}"
+# Optional W8A16 copy of the reduced draft head only. Full target weights and
+# acceptance are untouched. Original BF16 buffers remain for large-M fallback.
+MTP_DRAFT_HEAD_FP8="${MTP_DRAFT_HEAD_FP8:-0}"
+[[ "$MTP_DRAFT_HEAD_FP8" == 0 || "$MTP_DRAFT_HEAD_FP8" == 1 ]] \
+    || err "MTP_DRAFT_HEAD_FP8 must be 0 or 1"
+if [[ "$MTP_DRAFT_HEAD_FP8" == 1 ]]; then
+    [[ "$MTP_NUM_SPECULATIVE_TOKENS" -gt 0 && -n "$MTP_DRAFT_VOCAB" ]] \
+        || err "MTP_DRAFT_HEAD_FP8 requires MTP and MTP_DRAFT_VOCAB"
+fi
 # torch.compile level: 0 = none (shipped default), 3 = VLLM_COMPILE (Inductor
 # fusion; adds minutes to the first launch and has not been validated against
 # the PLE custom op here).
@@ -587,6 +596,16 @@ extract "$MTP_PKG" "$PATCHED_MTP.orig"
 python3 "$SCRIPT_DIR/files/patch_mtp_draft_vocab.py"
 [[ -f "$PATCHED_MTP" ]] || err "MTP patch missing after patch_mtp_draft_vocab.py"
 
+MTP_FP8_MOUNTS=""
+if [[ "$MTP_DRAFT_HEAD_FP8" == 1 ]]; then
+    MTP_FP8_DIR="$SCRIPT_DIR/files/mtp_fp8_generated"
+    mkdir -p "$MTP_FP8_DIR"
+    python3 "$SCRIPT_DIR/files/patch_mtp_fp8_head.py" \
+        --source "$PATCHED_MTP" --output "$MTP_FP8_DIR/mtp.py"
+    PATCHED_MTP="$MTP_FP8_DIR/mtp.py"
+    MTP_FP8_MOUNTS="-v $SCRIPT_DIR/files/spark_mtp_fp8_head.py:$VLLM_PKG/models/qwen3_8_flash_next/nvidia/spark_mtp_fp8_head.py:ro -e VLLM_MTP_DRAFT_HEAD_FP8=1"
+fi
+
 OFFLOAD_DIR="$SCRIPT_DIR/files/ple_offload"
 mkdir -p "$OFFLOAD_DIR/orig"
 extract "$VLLM_PKG/model_executor/layers/ple_offload_layer.py" "$OFFLOAD_DIR/orig/ple_offload_layer.py"
@@ -739,6 +758,7 @@ info "  SSM state:  ${MAMBA_SSM_CACHE_DTYPE:-float32 (checkpoint)}"
 info "  GDN prefill: $GDN_PREFILL_BACKEND"
 info "  MTP:        $MTP_NUM_SPECULATIVE_TOKENS $( [[ "$MTP_NUM_SPECULATIVE_TOKENS" -eq 0 ]] && echo '(disabled)')"
 info "  Draft vocab: ${MTP_DRAFT_VOCAB:-full (248320)}"
+info "  Draft-head FP8: $MTP_DRAFT_HEAD_FP8 (target head unchanged)"
 info "  Graphs:     $CUDAGRAPH_MODE  capture=${_CG_SIZES:-vllm-default}  compile-mode=$COMPILATION_MODE"
 info "  Port:       $PORT"
 info ""
@@ -772,6 +792,7 @@ docker run \\
     -v $HF_CACHE_DIR:/root/.cache/huggingface \\
     -v $HOME/.cache/vllm:/root/.cache/vllm \\
     $GDN_PREFILL_MOUNTS \\
+    $MTP_FP8_MOUNTS \\
     $EXTRA_DOCKER_ARGS \\
     $IMAGE \\
     $MODEL_ID \\

--- a/start.sh
+++ b/start.sh
@@ -109,7 +109,7 @@ _CLI_KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-}"
 _ENV_SNAPSHOT_VARS=(KV_TARGET_GIB HOST_RESERVE_GIB HOST_SLACK_GIB OS_RESERVE_GIB
                     MEMWATCH_MIN_GIB MEMWATCH_MIN_FREE_GIB MEMWATCH_FREE_GATE_GIB MEMWATCH_GRACE
                     OVERHEAD_GIB PLE_GIB CONTAINER_MEM_GIB KV_CACHE_MEMORY
-                    MAMBA_SSM_CACHE_DTYPE
+                    MAMBA_SSM_CACHE_DTYPE GDN_PREFILL_BACKEND
                     IMAGE SERVED_MODEL_NAME CUDAGRAPH_MODE HF_TOKEN
                     CUDAGRAPH_CAPTURE_SIZES COMPILATION_MODE MTP_K_SCHEDULE
                     MTP_DRAFT_VOCAB
@@ -178,6 +178,13 @@ KV_CACHE_MEMORY="${KV_CACHE_MEMORY:-}"          # optional hard pin, bytes
 # costs to read and write every step, and halves the mamba page, which lets
 # vLLM pick a smaller attention block. Empty keeps the checkpoint's float32.
 MAMBA_SSM_CACHE_DTYPE="${MAMBA_SSM_CACHE_DTYPE:-}"
+# Preserve stock auto selection by default. FlashInfer on SM121 is opt-in and
+# source-checked against the tested image; it changes prefill only, not decode.
+GDN_PREFILL_BACKEND="${GDN_PREFILL_BACKEND:-auto}"
+case "$GDN_PREFILL_BACKEND" in
+    auto|triton|flashinfer) ;;
+    *) err "GDN_PREFILL_BACKEND must be auto, triton, or flashinfer" ;;
+esac
 # Runtime overhead on top of weights, GiB (measured at TP1: 3.37+1.92+0.12).
 OVERHEAD_GIB="${OVERHEAD_GIB:-5.6}"
 # KV the derived budget targets when GMU is not pinned. More KV = more UVM.
@@ -610,6 +617,19 @@ fi
 PLE_ORG="${PLE_CACHE_ID%%/*}"; PLE_NAME="${PLE_CACHE_ID##*/}"
 PLE_CACHE_HOST="$HOME/.cache/vllm/ple_cache/${PLE_ORG}--${PLE_NAME}"
 PLE_CACHE_CTR="/root/.cache/vllm/ple_cache/${PLE_ORG}--${PLE_NAME}"
+
+GDN_PREFILL_MOUNTS=""
+if [[ "$GDN_PREFILL_BACKEND" == flashinfer ]]; then
+    GDN_PREFILL_DIR="$SCRIPT_DIR/files/gdn_sm121_generated"
+    mkdir -p "$GDN_PREFILL_DIR"
+    docker run --rm --network none --memory 512m \
+        -v "$SCRIPT_DIR/files/patch_gdn_sm121.py:/patch_gdn_sm121.py:ro" \
+        -v "$GDN_PREFILL_DIR:/out" \
+        --entrypoint python3 "$IMAGE" /patch_gdn_sm121.py \
+        --output /out/qwen_gdn_linear_attn.py
+    GDN_PREFILL_MOUNTS="-v $GDN_PREFILL_DIR/qwen_gdn_linear_attn.py:$VLLM_PKG/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py:ro"
+fi
+
 if ! ls "$PLE_CACHE_HOST"/*.packed_u8 >/dev/null 2>&1; then
     info "Building packed PLE table (one-time, ~40 s, <1 GiB RAM, no GPU)..."
     mkdir -p "$PLE_CACHE_HOST"
@@ -641,6 +661,11 @@ fi
 VLLM_ARGS+=("--load-format" "safetensors")
 VLLM_ARGS+=("--safetensors-load-strategy" "lazy")
 VLLM_ARGS+=("--enable-chunked-prefill")
+if [[ "$GDN_PREFILL_BACKEND" != auto ]]; then
+    [[ "$EXTRA_VLLM_ARGS" != *--additional-config* ]] \
+        || err "GDN_PREFILL_BACKEND owns --additional-config; remove it from EXTRA_VLLM_ARGS."
+    VLLM_ARGS+=("--additional-config" "'{\"gdn_prefill_backend\":\"$GDN_PREFILL_BACKEND\"}'")
+fi
 VLLM_ARGS+=("--reasoning-parser" "qwen3")
 VLLM_ARGS+=("--enable-auto-tool-choice")
 VLLM_ARGS+=("--tool-call-parser" "qwen3_coder")
@@ -711,6 +736,7 @@ fi
 info "  GMU:        $GPU_MEMORY_UTILIZATION  (budget ${BUDGET_GIB} GiB, cgroup cap ${CONTAINER_MEM_GIB} GiB)"
 info "  Max seqs:   $MAX_NUM_SEQS   Batched tokens: $MAX_NUM_BATCHED_TOKENS   KV dtype: $KV_CACHE_DTYPE"
 info "  SSM state:  ${MAMBA_SSM_CACHE_DTYPE:-float32 (checkpoint)}"
+info "  GDN prefill: $GDN_PREFILL_BACKEND"
 info "  MTP:        $MTP_NUM_SPECULATIVE_TOKENS $( [[ "$MTP_NUM_SPECULATIVE_TOKENS" -eq 0 ]] && echo '(disabled)')"
 info "  Draft vocab: ${MTP_DRAFT_VOCAB:-full (248320)}"
 info "  Graphs:     $CUDAGRAPH_MODE  capture=${_CG_SIZES:-vllm-default}  compile-mode=$COMPILATION_MODE"
@@ -745,6 +771,7 @@ docker run \\
     -v $OFFLOAD_DIR/protocol.py:$VLLM_PKG/v1/ple_offload/protocol.py:ro \\
     -v $HF_CACHE_DIR:/root/.cache/huggingface \\
     -v $HOME/.cache/vllm:/root/.cache/vllm \\
+    $GDN_PREFILL_MOUNTS \\
     $EXTRA_DOCKER_ARGS \\
     $IMAGE \\
     $MODEL_ID \\


### PR DESCRIPTION
## Summary

Two independent, default-off optimizations for one GB10:

- `GDN_PREFILL_BACKEND=flashinfer`: enable the validated SM121 FlashInfer prefill path.
- `MTP_DRAFT_HEAD_FP8=1`: **experimental** FP8 reduced MTP draft head; target weights and rejection sampling unchanged.

Credit to **Gabriel Olympie (@gabrielolympie)** for the original [SM120 optimization work](https://github.com/gabrielolympie/sglang-flashnext-sm120/tree/67d2f9234fa45ae1339f0d53cd37cb695e9c6493).
This adapts his kernel ideas to GB10/vLLM; attribution and the Apache-2.0 kernel license are included.

## Coding comparison

Same Spark/image/checkpoint, native 262K, MTP3, 65K draft vocabulary, BF16 recurrent state, 32-GiB host reserve; thinking off. Three repeats per task/concurrency, 200 requests across four profiles. Baseline already includes Mia's existing optimizations.

| Measurement | Baseline | Both enabled | Change |
|---|---:|---:|---:|
| Solo code decode | 53.81 tok/s | 56.76 | +5.5% |
| Two streams, decode per request | 44.27 tok/s | 45.85 | +3.6% |
| Four streams, decode per request | 35.49 tok/s | 35.96 | +1.3% |
| Cold 6,941-token code prefill | 1,959 tok/s | 2,088 | +6.6% |
| Cold 27,120-token code prefill | 2,027 tok/s | 2,140 | +5.5% |

Decode excludes prefill. **Four-stream batch throughput was effectively flat**, and faster tokens did not consistently shorten completed-task latency.

Fixed execution tests passed **42/44 baseline vs 40/44 combined** (both 35/36 on the four main short tasks). Some failures involve an ambiguous interval specification; both FP8 profiles also produced a real relative-path bug. This small suite does **not** establish quality equivalence. FP8 adds **0.1565 GiB** at 65K vocabulary; host reserve is unchanged.

## Validation

Source-exact guards, nine CPU tests, isolated GDN/state and actual-head numerical checks, four-way serving A/B, cache continuation, tools, and Chat/Responses streaming telemetry. All 176 measured code outputs completed naturally; no serving OOM kills, unexpected restarts, or preemptions.

Rebased onto current `78b0675`; measurements remain from `ef1af5f`. The rebased launcher is dry-run/source-tested, not presented as a new performance run. The gated checkpoint was not tested.

[Full four-way results, methodology, memory/startup caveats, and per-feature checks](https://github.com/rwl4/Qwen3.8-Flash-Next-Single-DGX-Spark/blob/perf/sm121-gdn-fp8/docs/sm121-code-benchmarks.md).