### PR TITLE
Fix the quoting that brakes download.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ are grouped by date, newest first. Every measurement named here was taken on the
 one DGX Spark this repo is written for — treat them as that host's numbers, not
 as promises.
 
+## 2026-09-08
+
+### Fixed
+
+- **`download.sh` exited before downloading anything** (`download.sh`). The 403
+  branch built its retry hint with a single-quoted Python default inside the
+  single-quoted `$DL_PY` shell string, which closed that string early; bash
+  re-parsed the remainder and tried to run `./download.sh}", …` as a command.
+  Every invocation — gated or not, `ABLIT=0` or `ABLIT=1` — exited with
+  `line 214: … No such file or directory` before contacting Hugging Face, so
+  the message that branch exists to print was never reachable. The default now
+  lives in a `hint` local, leaving the embedded program with double quotes only.
+
 ## 2026-09-06
 
 Overnight measurement pass through `docs/synthesis-astra-fable-2026-09-05.md`

--- a/download.sh
+++ b/download.sh
@@ -206,12 +206,13 @@ except Exception as e:
         or " 403" in f" {text}"
     )
     if gated:
+        hint = sys.argv[2] if len(sys.argv) > 2 else "HF_TOKEN=hf_... ./download.sh"
         print(
             "403: this repo is gated.\n"
             "Accept the terms on that page:\n"
             f"  https://huggingface.co/{sys.argv[1]}\n"
             "Then retry with HF_TOKEN set:\n"
-            f"  {sys.argv[2] if len(sys.argv) > 2 else 'HF_TOKEN=hf_... ./download.sh'}",
+            f"  {hint}",
             file=sys.stderr,
         )
         sys.exit(1)


### PR DESCRIPTION
The 403 branch built its retry hint with a single-quoted Python default:

    f"  {sys.argv[2] if len(sys.argv) > 2 else 'HF_TOKEN=hf_... ./download.sh'}",

but that program lives in a single-quoted shell string, and bash has no escape for a single quote inside one. The first inner quote closed $DL_PY; the rest of the block was re-parsed as shell, where `./download.sh'` opened a fresh string running to the assignment's own closing quote. Bash then tried to execute a single word beginning `./download.sh}",` and the script exited 127 on every run -- gated or not, ABLIT=0 or ABLIT=1 -- before a byte was fetched. The message the branch existed to print was unreachable from the moment it landed.

Hoist the default into a `hint` local so the block contains double quotes only.

Verified: bash download.sh