### PR TITLE
download.sh: fix the single quote that truncates the DL_PY block (breaks ABLIT=1 downloads)

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -189,6 +189,8 @@ mkdir -p "$HF_CACHE_DIR"
 DL_PY='
 import os, sys
 from huggingface_hub import snapshot_download
+# No single quotes inside this block: it lives in a single-quoted bash string.
+DEFAULT_CMD = "HF_TOKEN=hf_... ./download.sh"
 try:
     p = snapshot_download(
         repo_id=sys.argv[1],
@@ -211,7 +213,7 @@ except Exception as e:
             "Accept the terms on that page:\n"
             f"  https://huggingface.co/{sys.argv[1]}\n"
             "Then retry with HF_TOKEN set:\n"
-            f"  {sys.argv[2] if len(sys.argv) > 2 else 'HF_TOKEN=hf_... ./download.sh'}",
+            f"  {sys.argv[2] if len(sys.argv) > 2 else DEFAULT_CMD}",
             file=sys.stderr,
         )
         sys.exit(1)


### PR DESCRIPTION
## Description and Motivation

`download.sh` cannot reach `snapshot_download` on current `main` (78b0675). The Python source in the `DL_PY='...'` block contains

```python
f"  {sys.argv[2] if len(sys.argv) > 2 else 'HF_TOKEN=hf_... ./download.sh'}",
```

and that inner `'` terminates the single-quoted bash string. Everything after it is handed to bash as a command line, so the script dies before downloading anything:

```
./download.sh: line 214: ./download.sh}",
            file=sys.stderr,
        )
        sys.exit(1)
    raise
print(p)
: No such file or directory
```

`bash -n download.sh` passes, because the truncated remainder is still valid shell syntax; it only fails at runtime. Any invocation that actually needs to download hits it. In practice that is `ABLIT=1 ./download.sh`, since the stock checkpoint is usually already in the cache and takes the "Already in cache" early exit.

The fix moves the default command into a `DEFAULT_CMD` variable defined with double quotes, so the block contains no single quotes at all, and leaves a one-line comment so the constraint is visible to the next edit. No `.env` knob, no measured number, and nothing memory-related changes.

Before: `ABLIT=1 ./download.sh` exits with the error above, `DL_PY` is empty.
After: the block is 33 lines, compiles, and the gated download runs.

## Related Issues

None filed; found while switching a Spark to `ABLIT=1` on 2026-09-08.

---

## Testing

- `bash -n download.sh`
- Extracted the block the way bash sees it and compiled it:
  `bash -c 'source <(sed -n "/^DL_PY=/,/^'"'"'$/p" download.sh); printf "%s" "$DL_PY" > /tmp/dl.py; python3 -m py_compile /tmp/dl.py'`
  On `main` this prints the `No such file or directory` error and `/tmp/dl.py` is empty. On this branch it compiles (33 lines).
- Confirmed there are zero `'` characters left inside the block.
- The same `snapshot_download(repo_id, token, max_workers=4)` call fetched the full Keys ablit snapshot (57 files, 99 GiB, 925 s) on a DGX Spark with `huggingface_hub` 1.30.0 / Python 3.12.3, and `ABLIT=1 ./download.sh` on this branch then takes the "Already in cache ... Nothing to do" path against it.
- `ABLIT=1 ./start.sh` afterwards serves `drowzeys/keys-Qwen3.8-flash-next-ablit-Mia-Single-Spark-only` with the reused packed PLE table (`edit_ple=false`), MTP 3, same KV pool as stock.

---

## Checklist:

- [x] I have read the README and `.env.sample` and kept my changes consistent with them.
- [x] My pull request has a sound title and description (not something vague like `Update README.md`).
- [x] My change is reproducible and verified (script syntax check, a dry run, a launch, or a re-measurement).
- [x] I edited the patch **generators** (`files/patch_*.py`), not the generated `*_patched.py` / `files/ple_offload/*.py` outputs, which are overwritten on every launch. (Not applicable: `download.sh` only.)
- [x] I updated the README and/or `.env.sample` if a `.env` knob, default, or measured number changed. (Nothing changed.)
- [x] If my change affects the memory budget, I re-checked it against the host `MemAvailable` floor in the README's safety rules. (Not applicable.)
- [x] Defaults in `.env.sample` still work out of the box; a new knob has a sane fallback like the existing ones.
- [x] I added any new tracked file to `.gitignore` (it is an allowlist: everything is ignored unless explicitly re-included). (No new files.)
