### PR TITLE
ABLIT=1: serve a 0.7-strength ablit checkpoint instead of Keys' full splice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ are grouped by date, newest first. Every measurement named here was taken on the
 one DGX Spark this repo is written for — treat them as that host's numbers, not
 as promises.
 
+## 2026-09-12
+
+### Changed
+
+- **`ABLIT=1` now serves `iSkye/Qwen3.8-Flash-Next-NVFP4-ablit-a070`** (`start.sh`,
+  `download.sh`, `README.md`): Keys' `o_proj` splice at 70% strength, same Mia
+  34-shard layout, same size, same gate terms. Keys' full-strength checkpoint
+  was clean on neutral prompts but collapsed into empty numbered lists on any
+  refusal-adjacent input and stayed there (issue #36); fp8 KV, bf16 SSM state
+  and the PLE table were each ruled out, the cause is in the nine edited
+  tensors. Interpolating them 0.7 of the way from stock keeps the refusal
+  bypass and the boundary region coherent. The checkpoint ships an
+  `ABLIT_META.json` with `edit_ple: false`, so the stock PLE table is still
+  reused and no launcher logic changed.
+
 ## 2026-09-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -427,12 +427,26 @@ benchmarked end to end.
 ### Abliterated checkpoint (`ABLIT`)
 
 `ABLIT=0` serves the stock Mia NVFP4 checkpoint. `ABLIT=1` serves the gated
-Keys checkpoint
-[`drowzeys/keys-Qwen3.8-flash-next-ablit-Mia-Single-Spark-only`](https://huggingface.co/drowzeys/keys-Qwen3.8-flash-next-ablit-Mia-Single-Spark-only):
-the same Mia 34-shard layout with QSA `self_attn.o_proj` replaced at layers
-15, 19, 23, 27, 31, 35, 39, 43 and 47. MTP, PLE, routed experts and the chat
-template stay stock. It is valid **only** on this recipe — do not use it with
-other NVFP4 / FP8 / BF16 / GGUF trees.
+abliterated checkpoint
+[`iSkye/Qwen3.8-Flash-Next-NVFP4-ablit-a070`](https://huggingface.co/iSkye/Qwen3.8-Flash-Next-NVFP4-ablit-a070):
+the same Mia 34-shard layout with QSA `self_attn.o_proj` at layers 15, 19, 23,
+27, 31, 35, 39, 43 and 47 moved **70% of the way from stock toward Keys'
+abliteration splice** (`W = W_stock + 0.7 · (W_ablit − W_stock)`, requantized
+to the recipe's MXFP8). MTP, PLE, routed experts and the chat template stay
+stock. It is valid **only** on this recipe — do not use it with other NVFP4 /
+FP8 / BF16 / GGUF trees.
+
+Why 0.7 and not Keys' full-strength splice: on this host the full splice is
+clean on neutral prompts but collapses on exactly the inputs an ablit is used
+for. Anything stock would refuse or deflect turns into empty numbered lists
+(`1. Hello`, `1.`) and the conversation stays there — the "ignores every prompt
+and repeats itself" of issue #36. The serving profile is not the cause (fp8 KV,
+bf16 SSM state and the packed PLE table were each ruled out by measurement);
+the delta per edited layer is a rank-1 injection about 6× stock energy, and
+scaling it to 0.7 keeps the refusal bypass while the boundary region stays
+coherent. 0.6 measured the same; 0.8 already leaks list-form answers again.
+The checkpoint's `ABLIT_META.json` records the method, both source snapshots
+and the effective strength per layer.
 
 Both checkpoints are **byte-for-byte the same size** (105,879,543,020 bytes of
 safetensors): `o_proj` is a fixed-shape `F8_E4M3 [2560, 6144]` tensor, so
@@ -453,28 +467,30 @@ ABLIT=1 ./start.sh
 `HF_TOKEN` is required for `ABLIT=1`. A 403 means access has not been granted
 yet — **Accept the terms on that page**, then retry with `HF_TOKEN` set. Stock
 and ablit caches sit side by side; flipping `ABLIT` is the only switch. The
-packed PLE table is reused from stock (those shards are unchanged), so
-`start.sh` does not rebuild the 27 GiB table.
+packed PLE table is reused from stock (those shards are unchanged, and the
+checkpoint's `ABLIT_META.json` says so), so `start.sh` does not rebuild the
+27 GiB table.
 
-**The gate is a binding agreement, not a download button.** The checkpoint
-ships its own `RESPONSIBLE_USE.md`, and requesting access means accepting it.
-In summary: you must be 18 or older, you state your intended use on the request
-form, and the terms prohibit sexual content involving minors, material
-promoting self-harm or suicide, harassment, doxxing or fraud targeting real
-people, anything illegal in your jurisdiction, and any use barred by the
-upstream Qwen Community License. The weights are provided as-is with no
-warranty and inherit their licence from the upstream Qwen base model. Read
-`RESPONSIBLE_USE.md` and `COMPATIBILITY.md` in the repo before requesting
-access — this paragraph is a summary, and the repo's own terms are what bind.
+**The gate is a binding agreement, not a download button.** The access form
+carries the same Responsible Use terms as Keys' checkpoint, and requesting
+access means accepting them. In summary: you must be 18 or older, you state
+your intended use on the request form, and the terms prohibit sexual content
+involving minors, material promoting self-harm or suicide, harassment, doxxing
+or fraud targeting real people, anything illegal in your jurisdiction, and any
+use barred by the upstream Qwen Community License. The weights are provided
+as-is with no warranty and inherit their licence from the upstream Qwen base
+model. Read the terms on the repo page before requesting access — this
+paragraph is a summary, and the repo's own terms are what bind.
 
-Safety refusals are removed in this checkpoint, which moves the guardrails onto
-you: filtering, human review and access control are yours to supply. That
+Safety refusals are weakened in this checkpoint, which moves the guardrails
+onto you: filtering, human review and access control are yours to supply. That
 matters more here than on stock, because `start.sh` binds the server to
 `0.0.0.0` — anything that can reach the port can reach an unfiltered model.
 
-The abliteration splice is by **Keys (drowzeys)**, built on MiaAI Lab's
-single-Spark NVFP4 recipe over Qwen/Alibaba's Qwen3.8-Flash-Next. See the
-checkpoint's `CREDITS.md`, and [Credits](#credits) below.
+The abliteration splice this checkpoint interpolates toward is by **Keys
+(drowzeys)**, built on MiaAI Lab's single-Spark NVFP4 recipe over
+Qwen/Alibaba's Qwen3.8-Flash-Next; the 0.7 interpolation and its packaging are
+by **iSkye**. See [Credits](#credits) below.
 
 ### Reasoning is on by default
 
@@ -795,7 +811,7 @@ buffer or missing quant scales) — see the patch notes below.
 
 - `download.sh` — fetches the checkpoint into the Hugging Face cache
   (resumable; honours `HF_TOKEN` for gated repos). `ABLIT=1` downloads the
-  full Keys ablit snapshot after you accept the Hugging Face terms. Uses the
+  full ablit-a070 snapshot after you accept the Hugging Face terms. Uses the
   host's `huggingface_hub` if present, otherwise the container image.
 - `start.sh` — launcher: derives the GPU budget from live memory under the
   `HOST_RESERVE_GIB` cap, builds the packed PLE table on first run,
@@ -869,9 +885,11 @@ sparkDash's own figures include any other traffic on the port.
   [`Mia-AiLab/Qwen3.8-Flash-Next-NVFP4`](https://huggingface.co/Mia-AiLab/Qwen3.8-Flash-Next-NVFP4).
 - **local-inference-lab** — the byte-identical Spark checkpoint used as the
   splice base.
-- **Keys (drowzeys)** — the abliteration splice served by `ABLIT=1` (QSA
-  `o_proj` at L15–47 in MXFP8; MTP, routed experts, PLE and the chat template
-  left stock) and its packaging.
+- **Keys (drowzeys)** — the abliteration splice (QSA `o_proj` at L15–47 in
+  MXFP8; MTP, routed experts, PLE and the chat template left stock) that the
+  `ABLIT=1` checkpoint interpolates toward.
+- **iSkye** — the 0.7 interpolation of that splice served by `ABLIT=1`
+  (`iSkye/Qwen3.8-Flash-Next-NVFP4-ablit-a070`) and its packaging.
 - **[lancelind/qwen3.8-Flash-DGX](https://github.com/lancelind/qwen3.8-Flash-DGX)**
   (Apache-2.0) — the FP8-KV approach behind one patch here, reimplemented
   against this image's own sources. See
@@ -913,8 +931,7 @@ they operate on, each of which carries its own terms:
 - **The model checkpoint** `Mia-AiLab/Qwen3.8-Flash-Next-NVFP4` — weights are
   governed by the checkpoint's own license, not by this repository's.
 - **The abliterated checkpoint**
-  `drowzeys/keys-Qwen3.8-flash-next-ablit-Mia-Single-Spark-only`, served only
-  when you opt in with `ABLIT=1` — gated on Hugging Face behind its own
-  `RESPONSIBLE_USE.md` agreement, with its licence inherited from the upstream
-  Qwen base model. This repository ships a flag that can serve those weights.
+  `iSkye/Qwen3.8-Flash-Next-NVFP4-ablit-a070`, served only
+  when you opt in with `ABLIT=1` — gated on Hugging Face behind a Responsible
+  Use agreement, with its licence inherited from the upstream Qwen base model. This repository ships a flag that can serve those weights.
   It does not redistribute them and does not relicense them.

--- a/download.sh
+++ b/download.sh
@@ -13,9 +13,9 @@
 #
 # Usage:
 #   ./download.sh                       # stock Mia NVFP4 (ABLIT=0)
-#   ABLIT=1 ./download.sh               # gated Keys ablit checkpoint (~99 GiB, same as stock).
+#   ABLIT=1 ./download.sh               # gated ablit-a070 checkpoint (~99 GiB, same as stock).
 #                                       # Set HF_TOKEN, then accept the terms on
-#                                       # https://huggingface.co/drowzeys/keys-Qwen3.8-flash-next-ablit-Mia-Single-Spark-only
+#                                       # https://huggingface.co/iSkye/Qwen3.8-Flash-Next-NVFP4-ablit-a070
 #   ./download.sh Org/Some-Other-Model  # an explicit repo id
 #   HF_TOKEN=hf_... ./download.sh       # for a gated repo
 set -euo pipefail
@@ -50,7 +50,7 @@ ABLIT="${ABLIT:-0}"
 [[ -n "$_CLI_TP1_MODEL_ID" ]] && TP1_MODEL_ID="$_CLI_TP1_MODEL_ID"
 
 STOCK_MODEL_ID="Mia-AiLab/Qwen3.8-Flash-Next-NVFP4"
-ABLIT_MODEL_ID="drowzeys/keys-Qwen3.8-flash-next-ablit-Mia-Single-Spark-only"
+ABLIT_MODEL_ID="iSkye/Qwen3.8-Flash-Next-NVFP4-ablit-a070"
 if [[ $# -gt 0 ]]; then
     MODEL_ID="$1"
 elif [[ -n "${TP1_MODEL_ID:-}" ]]; then

--- a/start.sh
+++ b/start.sh
@@ -5,9 +5,11 @@
 # tp1/start.sh — Single-node, single-GPU (TP=1) vLLM launch on ONE DGX Spark.
 #
 # Serves the Mia-AiLab NVFP4 checkpoint — MXFP8 attention + a 4-bit NVFP4 PLE
-# table. ABLIT=1 in .env switches to the gated Keys checkpoint
-# (drowzeys/keys-Qwen3.8-flash-next-ablit-Mia-Single-Spark-only): same Mia
-# 34-shard layout, QSA self_attn.o_proj replaced at L15/19/23/27/31/35/39/43/47.
+# table. ABLIT=1 in .env switches to the gated abliterated checkpoint
+# (iSkye/Qwen3.8-Flash-Next-NVFP4-ablit-a070): same Mia 34-shard layout,
+# QSA self_attn.o_proj at L15/19/23/27/31/35/39/43/47 interpolated 70% of the
+# way from stock toward Keys' abliteration splice (Keys at full strength
+# degenerates into numbered lists on refusal-adjacent input; 0.7 does not).
 # That repo is gated — accept the Hugging Face terms, then ABLIT=1 ./download.sh.
 # The memory figures below were measured on the equivalent
 # local-inference-lab build (98.6 GiB on disk); re-check them if this
@@ -66,7 +68,7 @@
 # length; YARN_MAX_MODEL_LEN (default 524288) is served instead when YARN=1.
 # Both live in .env, so the 0/1 flag alone switches between them. 1M does not fit.
 # ABLIT=0/1 likewise switches the checkpoint: 0 is stock Mia NVFP4, 1 is the
-# gated Keys ablit snapshot (accept Hugging Face terms, then ./download.sh).
+# gated ablit-a070 snapshot (accept Hugging Face terms, then ./download.sh).
 # ---------------------------------------------------------------------------
 #
 # Usage:
@@ -134,8 +136,8 @@ done
 # Defaults (see tp1/.env.sample for the known-good profile).
 # ---------------------------------------------------------------------------
 STOCK_MODEL_ID="Mia-AiLab/Qwen3.8-Flash-Next-NVFP4"
-ABLIT_MODEL_ID="drowzeys/keys-Qwen3.8-flash-next-ablit-Mia-Single-Spark-only"
-# Abliterated weights: 0 = stock Mia NVFP4, 1 = gated Keys checkpoint
+ABLIT_MODEL_ID="iSkye/Qwen3.8-Flash-Next-NVFP4-ablit-a070"
+# Abliterated weights: 0 = stock Mia NVFP4, 1 = gated ablit-a070 checkpoint
 # (QSA o_proj L15/19/23/27/31/35/39/43/47). Same 0/1 pattern as YARN.
 # TP1_MODEL_ID, if set, still wins and ABLIT is ignored for selection.
 ABLIT="${_CLI_ABLIT:-${ABLIT:-0}}"
@@ -270,8 +272,8 @@ if ! [[ "$MAX_MODEL_LEN" =~ ^[1-9][0-9]*$ ]]; then
 fi
 [[ "$YARN" == "0" || "$YARN" == "1" ]] || err "YARN must be 0 or 1 (got: '$YARN')"
 if [[ "$ABLIT" == "1" ]]; then
-    warn "ABLIT=1: serving gated Keys checkpoint ($ABLIT_MODEL_ID)."
-    warn "     Safety refusals are removed. MTP, PLE, experts and the chat template stay stock."
+    warn "ABLIT=1: serving gated abliterated checkpoint ($ABLIT_MODEL_ID)."
+    warn "     Safety refusals are weakened. MTP, PLE, experts and the chat template stay stock."
     warn "     Compatible ONLY with the Mia single-Spark NVFP4 layout (this recipe)."
 fi
 
@@ -605,7 +607,7 @@ for f in ple_offload_layer connector worker protocol; do
 done
 ok "Patches ready."
 
-# The Keys splice leaves the PLE n-gram shards stock, so the packed table is
+# The ablit edit leaves the PLE n-gram shards stock, so the packed table is
 # shared with the Mia checkpoint instead of rebuilt (~27 GiB). Read that from the
 # checkpoint's own metadata rather than assuming it: if a future ablit ever
 # touches PLE, build a separate table instead of poisoning the stock cache.
@@ -714,7 +716,7 @@ VLLM_ARGS_STR="${VLLM_ARGS[*]}"
 info ""
 info "Config (single Spark, TP=1):"
 info "  Model:      $MODEL_ID"
-info "  Ablit:      $ABLIT$( [[ "$ABLIT" == "1" ]] && echo ' (gated Keys o_proj L15-47)' )"
+info "  Ablit:      $ABLIT$( [[ "$ABLIT" == "1" ]] && echo ' (gated ablit-a070, o_proj L15-47)' )"
 info "  Image:      $IMAGE"
 if [[ -n "$YARN_FACTOR" ]]; then
 info "  Context:    $MAX_MODEL_LEN tokens (YaRN factor $YARN_FACTOR over native $NATIVE_MAX_MODEL_LEN)"


### PR DESCRIPTION
## What

`ABLIT=1` now serves `iSkye/Qwen3.8-Flash-Next-NVFP4-ablit-a070` instead of
`drowzeys/keys-Qwen3.8-flash-next-ablit-Mia-Single-Spark-only`. Same Mia
34-shard layout, same 105,879,543,020 bytes, same nine edited `o_proj`
tensors (L15/19/23/27/31/35/39/43/47), same gate terms. The only difference
is the strength: the tensors are interpolated 70% of the way from stock
toward Keys' splice (`W = W_stock + 0.7 · (W_ablit − W_stock)`), requantized
to the recipe's MXFP8 with per-group scales = max(stock, ablit).

Changed: `start.sh`, `download.sh` (model id and comments), `README.md`
(ABLIT section, credits, licence note), `CHANGELOG.md`. No launcher logic
changes. The checkpoint ships an `ABLIT_META.json` with `edit_ple: false`,
so the existing PLE-reuse path in `start.sh` works unchanged.

## Why

Keys' full-strength checkpoint is clean on neutral prompts but degenerates
on exactly the inputs an ablit is used for. Anything stock would refuse or
deflect turns into empty numbered lists (`1. Hello`, `1.`) and the
conversation stays there. That is the "doesn't follow any prompt, speaks
bullshit and repeats itself" of #36.

Ruled out by measurement on this host, one variable at a time: fp8 KV cache,
bf16 SSM state, the packed PLE table (#34's claim of PLE shards differing
does not reproduce: against `lfs.oid`-verified copies exactly 9 shards
differ, none of them PLE). The effect is in the weights. The delta per
edited layer is almost exactly rank 1 and is an injection, not a removal:
energy along the delta direction is ~6× stock (|uᵀW| 2.1 → 12.2), and the
nine directions are nearly uncorrelated across layers.

Scaling that injection down keeps the refusal bypass and restores coherence
in the boundary region:

| strength | neutral prompts | refusal-adjacent input |
|---|---|---|
| Keys (1.0) | clean | collapses to `1. Hello` |
| 0.6 | clean | coherent |
| **0.7** | clean | coherent, best of the series |
| 0.8 | clean | coherent, but list-form answers creep back |

Not measured: bypass on hard refusals. Memory footprint and PLE handling are
identical to stock and to Keys, so nothing in the memory budget moves.

## Notes for review

- The checkpoint is gated with the same Responsible Use terms as Keys'
  (18+, no minors, no self-harm, no harassment/doxxing/fraud, Qwen Community
  License), auto-approved after the form.
- Keys stays credited as the author of the splice; the checkpoint's
  `ABLIT_META.json` records both source snapshots and the effective strength
  per layer.
- If you would rather keep `ABLIT=1` pointing at Keys and add the 0.7 as a
  separate value, say so and I will rework it that way.
